### PR TITLE
Fix/badge count

### DIFF
--- a/src/main/java/com/mople/dto/client/UserClientResponse.java
+++ b/src/main/java/com/mople/dto/client/UserClientResponse.java
@@ -1,0 +1,12 @@
+package com.mople.dto.client;
+
+import lombok.Builder;
+
+@Builder
+public record UserClientResponse(
+        Long userId,
+        String nickname,
+        String image,
+        boolean isExistBadgeCount
+) {
+}

--- a/src/main/java/com/mople/dto/client/UserRoleClientResponse.java
+++ b/src/main/java/com/mople/dto/client/UserRoleClientResponse.java
@@ -9,32 +9,32 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record UserClientResponse(
+public record UserRoleClientResponse(
         Long userId,
         String nickname,
         String image,
         UserRole role
 ) {
-    public static List<UserClientResponse> ofParticipants(List<PlanParticipant> participants, Long hostId, Long creatorId) {
+    public static List<UserRoleClientResponse> ofParticipants(List<PlanParticipant> participants, Long hostId, Long creatorId) {
         return participants.stream()
                 .map(p -> ofUser(p.getUser(), hostId, creatorId))
                 .toList();
     }
 
-    public static List<UserClientResponse> ofAutoCompleteUsers(List<MeetMember> members, Long hostId, Long creatorId) {
+    public static List<UserRoleClientResponse> ofAutoCompleteUsers(List<MeetMember> members, Long hostId, Long creatorId) {
         return members.stream()
                 .map(m -> ofUser(m.getUser(), hostId, creatorId))
                 .toList();
     }
 
-    public static List<UserClientResponse> ofMembers(List<MeetMember> members, Long hostId) {
+    public static List<UserRoleClientResponse> ofMembers(List<MeetMember> members, Long hostId) {
         return members.stream()
                 .map(m -> ofUser(m.getUser(), hostId))
                 .toList();
     }
 
-    private static UserClientResponse ofUser(User user, Long hostId, Long creatorId) {
-        return UserClientResponse.builder()
+    private static UserRoleClientResponse ofUser(User user, Long hostId, Long creatorId) {
+        return UserRoleClientResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
                 .image(user.getProfileImg())
@@ -42,8 +42,8 @@ public record UserClientResponse(
                 .build();
     }
 
-    private static UserClientResponse ofUser(User user, Long hostId) {
-        return UserClientResponse.builder()
+    private static UserRoleClientResponse ofUser(User user, Long hostId) {
+        return UserRoleClientResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
                 .image(user.getProfileImg())

--- a/src/main/java/com/mople/dto/event/data/comment/CommentMentionEventData.java
+++ b/src/main/java/com/mople/dto/event/data/comment/CommentMentionEventData.java
@@ -11,8 +11,8 @@ import java.util.Map;
 @Getter
 public class CommentMentionEventData implements EventData {
 
+    private final String meetName;
     private final Long postId;
-    private final String postName;
     private final Long commentId;
     private final String commentContent;
     private final Long senderId;
@@ -21,12 +21,12 @@ public class CommentMentionEventData implements EventData {
 
     @Override
     public String getTitle() {
-        return postName + "에서 " + senderNickname + "님이 회원님을 멘션했어요!";
+        return meetName + "의 새로운 멘션 👀";
     }
 
     @Override
     public String getBody() {
-        return commentContent;
+        return meetName + "에서 " + senderNickname + "님이 회원님을 멘션했어요!";
     }
 
     @Override

--- a/src/main/java/com/mople/dto/event/data/comment/CommentReplyEventData.java
+++ b/src/main/java/com/mople/dto/event/data/comment/CommentReplyEventData.java
@@ -10,8 +10,8 @@ import java.util.Map;
 @Getter
 public class CommentReplyEventData implements EventData {
 
+    private final String meetName;
     private final Long postId;
-    private final String postName;
     private final Long commentId;
     private final String commentContent;
     private final Long senderId;
@@ -20,12 +20,12 @@ public class CommentReplyEventData implements EventData {
 
     @Override
     public String getTitle() {
-        return postName + "에서 " + senderNickname + "님이 답글을 남겼어요!";
+        return meetName + "의 새로운 대댓글 👀";
     }
 
     @Override
     public String getBody() {
-        return commentContent;
+        return meetName + "에서 " + senderNickname + "님이 답글을 남겼어요!";
     }
 
     @Override

--- a/src/main/java/com/mople/dto/event/data/plan/PlanCreateEventData.java
+++ b/src/main/java/com/mople/dto/event/data/plan/PlanCreateEventData.java
@@ -16,7 +16,7 @@ public class PlanCreateEventData implements EventData {
     private final Long planId;
     private final String planName;
     private final LocalDateTime planTime;
-    private final Long creatorId;
+    private final Long planCreatorId;
 
     @Override
     public String getTitle() {

--- a/src/main/java/com/mople/dto/event/data/plan/PlanDeleteEventData.java
+++ b/src/main/java/com/mople/dto/event/data/plan/PlanDeleteEventData.java
@@ -14,7 +14,7 @@ public class PlanDeleteEventData implements EventData {
     private final String meetName;
     private final Long planId;
     private final String planName;
-    private final Long deletedBy;
+    private final Long planDeletedBy;
 
     @Override
     public String getTitle() {

--- a/src/main/java/com/mople/dto/event/data/plan/PlanRemindEventData.java
+++ b/src/main/java/com/mople/dto/event/data/plan/PlanRemindEventData.java
@@ -16,7 +16,7 @@ public class PlanRemindEventData implements EventData {
     private final Long planId;
     private final String planName;
     private final LocalDateTime planTime;
-    private final Long creatorId;
+    private final Long planCreatorId;
     private final Double temperature;
     private final String iconImage;
 

--- a/src/main/java/com/mople/dto/event/data/plan/PlanUpdateEventData.java
+++ b/src/main/java/com/mople/dto/event/data/plan/PlanUpdateEventData.java
@@ -14,7 +14,7 @@ public class PlanUpdateEventData implements EventData {
     private final String meetName;
     private final Long planId;
     private final String planName;
-    private final Long updatedBy;
+    private final Long planUpdatedBy;
 
     @Override
     public String getTitle() {

--- a/src/main/java/com/mople/dto/event/data/review/ReviewRemindEventData.java
+++ b/src/main/java/com/mople/dto/event/data/review/ReviewRemindEventData.java
@@ -14,7 +14,7 @@ public class ReviewRemindEventData implements EventData {
     private final String meetName;
     private final Long reviewId;
     private final String reviewName;
-    private final Long creatorId;
+    private final Long reviewCreatorId;
 
     @Override
     public String getTitle() {

--- a/src/main/java/com/mople/dto/event/data/review/ReviewUpdateEventData.java
+++ b/src/main/java/com/mople/dto/event/data/review/ReviewUpdateEventData.java
@@ -14,7 +14,7 @@ public class ReviewUpdateEventData implements EventData {
     private final String meetName;
     private final Long reviewId;
     private final String reviewName;
-    private final Long creatorId;
+    private final Long reviewUpdatedBy;
 
     @Override
     public String getTitle() {

--- a/src/main/java/com/mople/dto/response/notification/NotificationResponse.java
+++ b/src/main/java/com/mople/dto/response/notification/NotificationResponse.java
@@ -19,6 +19,7 @@ public record NotificationResponse(
         NotifyType type,
         NotificationPayload payload,
         String sendAt,
+        boolean isRead,
         LocalDateTime planDate
 ) {
     public static List<NotificationResponse> of(
@@ -41,6 +42,7 @@ public record NotificationResponse(
                                         notification.getType(),
                                         mapper.readValue(notification.getPayload(), NotificationPayload.class),
                                         notification.getSendAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                                        notification.getReadAt() != null,
                                         getDate(notification.getPlanId(), notification.getReviewId(), timeMap)
                                 );
                             } catch (JsonProcessingException e) {
@@ -69,6 +71,8 @@ public record NotificationResponse(
         String getPayload();
 
         LocalDateTime getSendAt();
+
+        LocalDateTime getReadAt();
     }
 
     private static LocalDateTime getDate(Long planId, Long reviewId, Map<Long, LocalDateTime> timeMap) {

--- a/src/main/java/com/mople/entity/meet/comment/CommentLike.java
+++ b/src/main/java/com/mople/entity/meet/comment/CommentLike.java
@@ -10,17 +10,16 @@ import lombok.NoArgsConstructor;
 @Table(name = "comment_like")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(CommentLikeId.class)
 public class CommentLike {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(name = "user_id")
-    private Long userId;
-
     @Column(name = "comment_id")
     private Long commentId;
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
 
     @Builder
     public CommentLike(Long userId, Long commentId) {

--- a/src/main/java/com/mople/entity/meet/comment/CommentLikeId.java
+++ b/src/main/java/com/mople/entity/meet/comment/CommentLikeId.java
@@ -1,0 +1,19 @@
+package com.mople.entity.meet.comment;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@EqualsAndHashCode
+@NoArgsConstructor
+public class CommentLikeId implements Serializable {
+
+    private Long commentId;
+    private Long userId;
+
+    public CommentLikeId(Long commentId, Long userId) {
+        this.commentId = commentId;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/mople/entity/notification/Notification.java
+++ b/src/main/java/com/mople/entity/notification/Notification.java
@@ -75,7 +75,7 @@ public class Notification {
         this.user = user;
         this.payload = payload;
         this.sendAt = LocalDateTime.now();
-        this.expiredAt = LocalDateTime.now().plusYears(99);
+        this.expiredAt = LocalDateTime.now().plusDays(30);
         this.scheduledAt = scheduledAt;
     }
 

--- a/src/main/java/com/mople/global/event/data/notify/handler/impl/meet/MeetJoinNotifyHandler.java
+++ b/src/main/java/com/mople/global/event/data/notify/handler/impl/meet/MeetJoinNotifyHandler.java
@@ -34,7 +34,7 @@ public class MeetJoinNotifyHandler implements NotifyHandler<MeetJoinEventData> {
 
     @Override
     public NotifySendRequest getSendRequest(MeetJoinEventData data, NotificationEvent notify) {
-        return requestFactory.getMeetPushToken(data.getNewMemberId(), data.getMeetId(), notify.topic());
+        return requestFactory.getMeetPushTokens(data.getNewMemberId(), data.getMeetId(), notify.topic());
     }
 
     @Override

--- a/src/main/java/com/mople/global/event/data/notify/handler/impl/plan/PlanCreateNotifyHandler.java
+++ b/src/main/java/com/mople/global/event/data/notify/handler/impl/plan/PlanCreateNotifyHandler.java
@@ -34,7 +34,7 @@ public class PlanCreateNotifyHandler implements NotifyHandler<PlanCreateEventDat
 
     @Override
     public NotifySendRequest getSendRequest(PlanCreateEventData data, NotificationEvent notify) {
-        return requestFactory.getPlanPushToken(data.getCreatorId(), data.getPlanId(), notify.topic());
+        return requestFactory.getMeetPushTokens(data.getPlanCreatorId(), data.getMeetId(), notify.topic());
     }
 
     @Override

--- a/src/main/java/com/mople/global/event/data/notify/handler/impl/plan/PlanDeleteNotifyHandler.java
+++ b/src/main/java/com/mople/global/event/data/notify/handler/impl/plan/PlanDeleteNotifyHandler.java
@@ -39,7 +39,7 @@ public class PlanDeleteNotifyHandler implements NotifyHandler<PlanDeleteEventDat
 
     @Override
     public NotifySendRequest getSendRequest(PlanDeleteEventData data, NotificationEvent notify) {
-        return requestFactory.getPlanPushToken(data.getDeletedBy(), data.getPlanId(), notify.topic());
+        return requestFactory.getPlanPushTokens(data.getPlanDeletedBy(), data.getPlanId(), notify.topic());
     }
 
     @Override

--- a/src/main/java/com/mople/global/event/data/notify/handler/impl/plan/PlanRemindNotifyHandler.java
+++ b/src/main/java/com/mople/global/event/data/notify/handler/impl/plan/PlanRemindNotifyHandler.java
@@ -36,7 +36,7 @@ public class PlanRemindNotifyHandler implements NotifyHandler<PlanRemindEventDat
 
     @Override
     public NotifySendRequest getSendRequest(PlanRemindEventData data, NotificationEvent notify) {
-        return requestFactory.getPlanRemindToken(data.getPlanId(), notify.topic());
+        return requestFactory.getPlanPushTokensAll(data.getPlanId(), notify.topic());
     }
 
     @Override

--- a/src/main/java/com/mople/global/event/data/notify/handler/impl/plan/PlanUpdateNotifyHandler.java
+++ b/src/main/java/com/mople/global/event/data/notify/handler/impl/plan/PlanUpdateNotifyHandler.java
@@ -34,7 +34,7 @@ public class PlanUpdateNotifyHandler implements NotifyHandler<PlanUpdateEventDat
 
     @Override
     public NotifySendRequest getSendRequest(PlanUpdateEventData data, NotificationEvent notify) {
-        return requestFactory.getPlanPushToken(data.getUpdatedBy(), data.getPlanId(), notify.topic());
+        return requestFactory.getPlanPushTokens(data.getPlanUpdatedBy(), data.getPlanId(), notify.topic());
     }
 
     @Override

--- a/src/main/java/com/mople/global/event/data/notify/handler/impl/review/ReviewRemindNotifyHandler.java
+++ b/src/main/java/com/mople/global/event/data/notify/handler/impl/review/ReviewRemindNotifyHandler.java
@@ -34,7 +34,7 @@ public class ReviewRemindNotifyHandler implements NotifyHandler<ReviewRemindEven
 
     @Override
     public NotifySendRequest getSendRequest(ReviewRemindEventData data, NotificationEvent notify) {
-        return requestFactory.getReviewCreatorPushToken(data.getCreatorId(), notify.topic());
+        return requestFactory.getCreatorPushToken(data.getReviewCreatorId(), notify.topic());
     }
 
     @Override

--- a/src/main/java/com/mople/global/event/data/notify/handler/impl/review/ReviewUpdateNotifyHandler.java
+++ b/src/main/java/com/mople/global/event/data/notify/handler/impl/review/ReviewUpdateNotifyHandler.java
@@ -34,7 +34,7 @@ public class ReviewUpdateNotifyHandler implements NotifyHandler<ReviewUpdateEven
 
     @Override
     public NotifySendRequest getSendRequest(ReviewUpdateEventData data, NotificationEvent notify) {
-        return requestFactory.getReviewPushToken(data.getCreatorId(), data.getReviewId(), notify.topic());
+        return requestFactory.getReviewPushToken(data.getReviewUpdatedBy(), data.getReviewId(), notify.topic());
     }
 
     @Override

--- a/src/main/java/com/mople/meet/controller/CommentController.java
+++ b/src/main/java/com/mople/meet/controller/CommentController.java
@@ -2,7 +2,7 @@ package com.mople.meet.controller;
 
 import com.mople.core.annotation.auth.SignUser;
 import com.mople.dto.client.CommentClientResponse;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
 import com.mople.dto.response.pagination.CursorPageResponse;
@@ -127,7 +127,7 @@ public class CommentController {
             description = "입력한 키워드에 맞는 모임 멤버 닉네임을 자동 완성합니다."
     )
     @GetMapping("/{postId}/mention")
-    public CursorPageResponse<UserClientResponse> searchMention(
+    public CursorPageResponse<UserRoleClientResponse> searchMention(
             @Parameter(hidden = true) @SignUser AuthUserRequest user,
             @PathVariable Long postId,
             @RequestParam String keyword,

--- a/src/main/java/com/mople/meet/controller/MeetController.java
+++ b/src/main/java/com/mople/meet/controller/MeetController.java
@@ -2,7 +2,7 @@ package com.mople.meet.controller;
 
 import com.mople.core.annotation.auth.SignUser;
 import com.mople.dto.client.MeetClientResponse;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.request.meet.MeetCreateRequest;
 import com.mople.dto.request.meet.MeetUpdateRequest;
 import com.mople.dto.request.pagination.CursorPageRequest;
@@ -83,7 +83,7 @@ public class MeetController {
             description = "모임 유저 목록을 조회합니다."
     )
     @GetMapping("/members/{meetId}")
-    public ResponseEntity<FlatCursorPageResponse<UserClientResponse>> getMeetMembers(
+    public ResponseEntity<FlatCursorPageResponse<UserRoleClientResponse>> getMeetMembers(
             @Parameter(hidden = true) @SignUser AuthUserRequest user,
             @PathVariable Long meetId,
             @ParameterObject @Valid CursorPageRequest request

--- a/src/main/java/com/mople/meet/controller/PlanController.java
+++ b/src/main/java/com/mople/meet/controller/PlanController.java
@@ -3,7 +3,7 @@ package com.mople.meet.controller;
 import com.mople.core.annotation.auth.SignUser;
 import com.mople.core.annotation.log.BusinessLogicLogging;
 import com.mople.dto.client.PlanClientResponse;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.request.meet.plan.PlanReportRequest;
 import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
@@ -151,7 +151,7 @@ public class PlanController {
             description = "일정에 참가하는 유저 정보를 반환합니다."
     )
     @GetMapping("/participants/{planId}")
-    public ResponseEntity<FlatCursorPageResponse<UserClientResponse>> getParticipants(
+    public ResponseEntity<FlatCursorPageResponse<UserRoleClientResponse>> getParticipants(
             @Parameter(hidden = true) @SignUser AuthUserRequest user,
             @PathVariable Long planId,
             @ParameterObject @Valid CursorPageRequest request

--- a/src/main/java/com/mople/meet/controller/ReviewController.java
+++ b/src/main/java/com/mople/meet/controller/ReviewController.java
@@ -2,7 +2,7 @@ package com.mople.meet.controller;
 
 import com.mople.core.annotation.auth.SignUser;
 import com.mople.dto.client.ReviewClientResponse;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.request.meet.review.ReviewImageDeleteRequest;
 import com.mople.dto.request.meet.review.ReviewReportRequest;
 import com.mople.dto.request.pagination.CursorPageRequest;
@@ -83,7 +83,7 @@ public class ReviewController {
             description = "후기에 참가하는 유저 정보를 반환합니다."
     )
     @GetMapping("/participants/{reviewId}")
-    public ResponseEntity<FlatCursorPageResponse<UserClientResponse>> getReviewParticipants(
+    public ResponseEntity<FlatCursorPageResponse<UserRoleClientResponse>> getReviewParticipants(
             @Parameter(hidden = true) @SignUser AuthUserRequest user,
             @PathVariable Long reviewId,
             @ParameterObject @Valid CursorPageRequest request

--- a/src/main/java/com/mople/meet/repository/comment/CommentLikeRepository.java
+++ b/src/main/java/com/mople/meet/repository/comment/CommentLikeRepository.java
@@ -1,6 +1,7 @@
 package com.mople.meet.repository.comment;
 
 import com.mople.entity.meet.comment.CommentLike;
+import com.mople.entity.meet.comment.CommentLikeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.Optional;
 
-public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+public interface CommentLikeRepository extends JpaRepository<CommentLike, CommentLikeId> {
 
     @Query("select cl.commentId from CommentLike cl where cl.userId = :userId and cl.commentId in :commentIds")
     List<Long> findLikedCommentIds(Long userId, List<Long> commentIds);

--- a/src/main/java/com/mople/meet/schedule/PlanScheduleJob.java
+++ b/src/main/java/com/mople/meet/schedule/PlanScheduleJob.java
@@ -98,7 +98,7 @@ public class PlanScheduleJob {
                                 .planId(meetPlan.getId())
                                 .planName(meetPlan.getName())
                                 .planTime(meetPlan.getPlanTime())
-                                .creatorId(userId)
+                                .planCreatorId(userId)
                                 .temperature(weather.temperature())
                                 .iconImage(weather.weatherIconImage())
                                 .build()
@@ -130,7 +130,7 @@ public class PlanScheduleJob {
                                     .meetName(review.getMeet().getName())
                                     .reviewId(review.getId())
                                     .reviewName(review.getName())
-                                    .creatorId(review.getCreatorId())
+                                    .reviewCreatorId(review.getCreatorId())
                                     .build()
                     )
             );

--- a/src/main/java/com/mople/meet/service/MeetService.java
+++ b/src/main/java/com/mople/meet/service/MeetService.java
@@ -2,7 +2,7 @@ package com.mople.meet.service;
 
 import com.mople.core.exception.custom.*;
 import com.mople.dto.client.MeetClientResponse;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.event.data.meet.MeetJoinEventData;
 import com.mople.dto.request.meet.MeetCreateRequest;
 import com.mople.dto.request.meet.MeetUpdateRequest;
@@ -32,7 +32,7 @@ import org.springframework.ui.Model;
 import java.util.*;
 
 import static com.mople.dto.client.MeetClientResponse.*;
-import static com.mople.dto.client.UserClientResponse.ofMembers;
+import static com.mople.dto.client.UserRoleClientResponse.ofMembers;
 import static com.mople.global.enums.ExceptionReturnCode.*;
 import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
 
@@ -172,7 +172,7 @@ public class MeetService {
     }
 
     @Transactional(readOnly = true)
-    public FlatCursorPageResponse<UserClientResponse> meetMemberList(Long userId, Long meetId, CursorPageRequest request) {
+    public FlatCursorPageResponse<UserRoleClientResponse> meetMemberList(Long userId, Long meetId, CursorPageRequest request) {
         reader.findUser(userId);
         Meet meet = reader.findMeet(meetId);
         validateMember(userId, meetId);
@@ -204,7 +204,7 @@ public class MeetService {
         return meetMemberRepositorySupport.findMemberPage(meetId, hostId, cursor, size);
     }
 
-    private CursorPageResponse<UserClientResponse> buildMemberCursorPage(int size, List<MeetMember> members, Long hostId) {
+    private CursorPageResponse<UserRoleClientResponse> buildMemberCursorPage(int size, List<MeetMember> members, Long hostId) {
         return buildCursorPage(
                 members,
                 size,

--- a/src/main/java/com/mople/meet/service/PlanService.java
+++ b/src/main/java/com/mople/meet/service/PlanService.java
@@ -143,7 +143,7 @@ public class PlanService {
                                 .planId(plan.getId())
                                 .planName(plan.getName())
                                 .planTime(plan.getPlanTime())
-                                .creatorId(user.getId())
+                                .planCreatorId(user.getId())
                                 .build()
                 )
         );
@@ -200,7 +200,7 @@ public class PlanService {
                                 .meetName(plan.getMeet().getName())
                                 .planId(plan.getId())
                                 .planName(plan.getName())
-                                .updatedBy(plan.getCreator().getId())
+                                .planUpdatedBy(plan.getCreator().getId())
                                 .build()
                 )
         );
@@ -224,7 +224,7 @@ public class PlanService {
                                 .meetName(plan.getMeet().getName())
                                 .planId(plan.getId())
                                 .planName(plan.getName())
-                                .deletedBy(plan.getCreator().getId())
+                                .planDeletedBy(plan.getCreator().getId())
                                 .build()
                 )
         );

--- a/src/main/java/com/mople/meet/service/PlanService.java
+++ b/src/main/java/com/mople/meet/service/PlanService.java
@@ -5,7 +5,7 @@ import com.mople.core.exception.custom.BadRequestException;
 import com.mople.core.exception.custom.CursorException;
 import com.mople.core.exception.custom.ResourceNotFoundException;
 import com.mople.dto.client.PlanClientResponse;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.event.data.plan.PlanCreateEventData;
 import com.mople.dto.event.data.plan.PlanDeleteEventData;
 import com.mople.dto.event.data.plan.PlanUpdateEventData;
@@ -57,7 +57,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static com.mople.dto.client.PlanClientResponse.*;
-import static com.mople.dto.client.UserClientResponse.ofParticipants;
+import static com.mople.dto.client.UserRoleClientResponse.ofParticipants;
 import static com.mople.global.enums.ExceptionReturnCode.*;
 import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
 
@@ -320,7 +320,7 @@ public class PlanService {
     }
 
     @Transactional(readOnly = true)
-    public FlatCursorPageResponse<UserClientResponse> getParticipantList(Long userId, Long planId, CursorPageRequest request) {
+    public FlatCursorPageResponse<UserRoleClientResponse> getParticipantList(Long userId, Long planId, CursorPageRequest request) {
         MeetPlan plan = reader.findPlan(planId);
         validateMemberByPlanId(userId, planId);
 
@@ -352,7 +352,7 @@ public class PlanService {
         return participantRepositorySupport.findPlanParticipantPage(planId, hostId, creatorId, cursor, size);
     }
 
-    private CursorPageResponse<UserClientResponse> buildParticipantCursorPage(int size, List<PlanParticipant> participants, Long hostId, Long creatorId) {
+    private CursorPageResponse<UserRoleClientResponse> buildParticipantCursorPage(int size, List<PlanParticipant> participants, Long hostId, Long creatorId) {
         return buildCursorPage(
                 participants,
                 size,

--- a/src/main/java/com/mople/meet/service/ReviewService.java
+++ b/src/main/java/com/mople/meet/service/ReviewService.java
@@ -258,7 +258,7 @@ public class ReviewService {
                                     .meetName(review.getMeet().getName())
                                     .reviewId(review.getId())
                                     .reviewName(review.getName())
-                                    .creatorId(review.getCreatorId())
+                                    .reviewUpdatedBy(review.getCreatorId())
                                     .build()
                     )
             );

--- a/src/main/java/com/mople/meet/service/ReviewService.java
+++ b/src/main/java/com/mople/meet/service/ReviewService.java
@@ -4,7 +4,7 @@ import com.mople.core.exception.custom.BadRequestException;
 import com.mople.core.exception.custom.CursorException;
 import com.mople.core.exception.custom.ResourceNotFoundException;
 import com.mople.dto.client.ReviewClientResponse;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.event.data.review.ReviewUpdateEventData;
 import com.mople.dto.request.meet.review.ReviewImageDeleteRequest;
 import com.mople.dto.request.meet.review.ReviewReportRequest;
@@ -45,7 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.mople.dto.client.ReviewClientResponse.*;
-import static com.mople.dto.client.UserClientResponse.ofParticipants;
+import static com.mople.dto.client.UserRoleClientResponse.ofParticipants;
 import static com.mople.global.enums.ExceptionReturnCode.*;
 import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
 
@@ -152,7 +152,7 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
-    public FlatCursorPageResponse<UserClientResponse> getReviewParticipants(Long userId, Long reviewId, CursorPageRequest request) {
+    public FlatCursorPageResponse<UserRoleClientResponse> getReviewParticipants(Long userId, Long reviewId, CursorPageRequest request) {
         PlanReview review = reader.findReview(reviewId);
         validateMemberByReviewId(userId, reviewId);
 
@@ -184,7 +184,7 @@ public class ReviewService {
         return participantRepositorySupport.findReviewParticipantPage(reviewId, hostId, creatorId, cursor, size);
     }
 
-    private CursorPageResponse<UserClientResponse> buildParticipantCursorPage(int size, List<PlanParticipant> participants, Long hostId, Long creatorId) {
+    private CursorPageResponse<UserRoleClientResponse> buildParticipantCursorPage(int size, List<PlanParticipant> participants, Long hostId, Long creatorId) {
         return buildCursorPage(
                 participants,
                 size,

--- a/src/main/java/com/mople/meet/service/comment/CommentAutoCompleteService.java
+++ b/src/main/java/com/mople/meet/service/comment/CommentAutoCompleteService.java
@@ -1,7 +1,7 @@
 package com.mople.meet.service.comment;
 
 import com.mople.core.exception.custom.CursorException;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.response.pagination.CursorPageResponse;
 import com.mople.global.utils.cursor.AutoCompleteCursor;
 import com.mople.entity.meet.MeetMember;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-import static com.mople.dto.client.UserClientResponse.ofAutoCompleteUsers;
+import static com.mople.dto.client.UserRoleClientResponse.ofAutoCompleteUsers;
 import static com.mople.global.enums.ExceptionReturnCode.*;
 import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
 
@@ -41,7 +41,7 @@ public class CommentAutoCompleteService {
         return memberRepositorySupport.findMemberAutoCompletePage(meetId, hostId, creatorId, keyword, cursor, size);
     }
 
-    public CursorPageResponse<UserClientResponse> buildAutoCompleteCursorPage(int size, List<MeetMember> members, Long hostId, Long creatorId) {
+    public CursorPageResponse<UserRoleClientResponse> buildAutoCompleteCursorPage(int size, List<MeetMember> members, Long hostId, Long creatorId) {
         return buildCursorPage(
                 members,
                 size,

--- a/src/main/java/com/mople/meet/service/comment/CommentEventPublisher.java
+++ b/src/main/java/com/mople/meet/service/comment/CommentEventPublisher.java
@@ -19,14 +19,14 @@ public class CommentEventPublisher {
     private final ApplicationEventPublisher publisher;
     private final NotificationUserReader userReader;
 
-    public void publishMentionEvent(List<Long> originMentions, List<Long> newMentions, PlanComment comment, String postName) {
+    public void publishMentionEvent(List<Long> originMentions, List<Long> newMentions, PlanComment comment, String meetName) {
         if (newMentions == null || newMentions.isEmpty()) return;
 
         publisher.publishEvent(
                 NotifyEventPublisher.commentMention(
                         CommentMentionEventData.builder()
                                 .postId(comment.getPostId())
-                                .postName(postName)
+                                .meetName(meetName)
                                 .commentId(comment.getId())
                                 .commentContent(comment.getContent())
                                 .senderId(comment.getWriter().getId())
@@ -37,7 +37,7 @@ public class CommentEventPublisher {
         );
     }
 
-    public void publishReplyEvent(List<Long> mentions, PlanComment comment, PlanComment parentComment, String postName) {
+    public void publishReplyEvent(List<Long> mentions, PlanComment comment, PlanComment parentComment, String meetName) {
         boolean parentIsMentioned = false;
 
         if (mentions != null && !mentions.isEmpty()) {
@@ -52,7 +52,7 @@ public class CommentEventPublisher {
                     NotifyEventPublisher.commentReply(
                             CommentReplyEventData.builder()
                                     .postId(comment.getPostId())
-                                    .postName(postName)
+                                    .meetName(meetName)
                                     .commentId(comment.getId())
                                     .commentContent(comment.getContent())
                                     .senderId(comment.getWriter().getId())

--- a/src/main/java/com/mople/meet/service/comment/CommentService.java
+++ b/src/main/java/com/mople/meet/service/comment/CommentService.java
@@ -150,8 +150,8 @@ public class CommentService {
         commentRepository.save(comment);
         mentionService.createMentions(request.mentions(), comment.getId());
 
-        String postName = getPostName(comment.getPostId());
-        commentEventPublisher.publishMentionEvent(null, request.mentions(), comment, postName);
+        String meetName = getMeetName(comment.getPostId());
+        commentEventPublisher.publishMentionEvent(null, request.mentions(), comment, meetName);
 
         boolean likedByMe = likeService.likedByMe(userId, comment.getId());
 
@@ -187,9 +187,9 @@ public class CommentService {
 
         commentRepository.increaseReplyCount(parentComment.getId());
 
-        String postName = getPostName(comment.getPostId());
-        commentEventPublisher.publishMentionEvent(null, request.mentions(), comment, postName);
-        commentEventPublisher.publishReplyEvent(request.mentions(), comment, parentComment, postName);
+        String meetName = getMeetName(comment.getPostId());
+        commentEventPublisher.publishMentionEvent(null, request.mentions(), comment, meetName);
+        commentEventPublisher.publishReplyEvent(request.mentions(), comment, parentComment, meetName);
 
         boolean likedByMe = likeService.likedByMe(userId, comment.getId());
 
@@ -208,8 +208,8 @@ public class CommentService {
         comment.updateContent(request.contents());
         mentionService.updateMentions(request.mentions(), comment.getId());
 
-        String postName = getPostName(comment.getPostId());
-        commentEventPublisher.publishMentionEvent(originMentions, request.mentions(), comment, postName);
+        String meetName = getMeetName(comment.getPostId());
+        commentEventPublisher.publishMentionEvent(originMentions, request.mentions(), comment, meetName);
 
         return getCommentUpdateClientResponse(userId, comment);
     }
@@ -221,11 +221,11 @@ public class CommentService {
         return ofUpdate(new CommentUpdateResponse(comment, mentionedUsers, likedByMe));
     }
 
-    private String getPostName(Long postId) {
+    private String getMeetName(Long postId) {
         try {
-            return reader.findPlan(postId).getName();
+            return reader.findPlan(postId).getMeet().getName();
         } catch (ResourceNotFoundException e) {
-            return reader.findReviewByPostId(postId).getName();
+            return reader.findReviewByPostId(postId).getMeet().getName();
         }
     }
 

--- a/src/main/java/com/mople/meet/service/comment/CommentService.java
+++ b/src/main/java/com/mople/meet/service/comment/CommentService.java
@@ -2,7 +2,7 @@ package com.mople.meet.service.comment;
 
 import com.mople.core.exception.custom.ResourceNotFoundException;
 import com.mople.dto.client.CommentClientResponse;
-import com.mople.dto.client.UserClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.request.meet.comment.CommentCreateRequest;
 import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.response.meet.comment.CommentResponse;
@@ -285,7 +285,7 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public CursorPageResponse<UserClientResponse> searchMeetMember(Long userId, Long postId, String keyword, CursorPageRequest request) {
+    public CursorPageResponse<UserRoleClientResponse> searchMeetMember(Long userId, Long postId, String keyword, CursorPageRequest request) {
         reader.findUser(userId);
         commentValidator.validatePostId(postId);
 

--- a/src/main/java/com/mople/notification/controller/NotificationController.java
+++ b/src/main/java/com/mople/notification/controller/NotificationController.java
@@ -90,17 +90,4 @@ public class NotificationController {
         service.readAllNotifications(user.id());
         return ResponseEntity.ok().build();
     }
-
-    @Operation(
-            summary = "특정 Notify 읽음 처리 API",
-            description = "특정 알림을 읽음 처리합니다."
-    )
-    @PutMapping("/read/{notificationId}")
-    public ResponseEntity<Void> readSingleNotification(
-            @Parameter(hidden = true) @SignUser AuthUserRequest user,
-            @PathVariable Long notificationId
-    ) {
-        service.readSingleNotification(user.id(), notificationId);
-        return ResponseEntity.ok().build();
-    }
 }

--- a/src/main/java/com/mople/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/mople/notification/repository/NotificationRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,12 +25,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                     "m.meet_image as meetImg, " +
                     "n.type as type, " +
                     "n.payload as payload, " +
-                    "n.send_at as sendAt " +
+                    "n.send_at as sendAt, " +
+                    "n.read_at as readAt " +
             "  from notification n " +
             "  join meet m " +
             "    on m.meet_id = n.meet_id " +
             " where n.user_id = :userId " +
             "   and n.action = :action " +
+            "   and n.expired_at > now() " +
             " order by n.notification_id DESC " +
             "limit :limit",
             nativeQuery = true
@@ -47,12 +48,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                     "m.meet_image as meetImg, " +
                     "n.type as type, " +
                     "n.payload as payload, " +
-                    "n.send_at as sendAt " +
+                    "n.send_at as sendAt, " +
+                    "n.read_at as readAt " +
             "  from notification n " +
             "  join meet m " +
             "    on m.meet_id = n.meet_id " +
             " where n.user_id = :userId " +
             "   and n.action = :action " +
+            "   and n.expired_at > now() " +
             "   and n.notification_id < :cursorId " +
             " order by n.notification_id DESC " +
             "limit :limit",
@@ -71,11 +74,11 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         "  from notification n " +
         " where n.user_id = :userId " +
         "   and n.action = :action " +
-        "   and n.read_at is null " +
-        "   and n.send_at >= :startDate",
+        "   and n.expired_at > now() " +
+        "   and n.read_at is null ",
             nativeQuery = true
     )
-    Long countBadgeCount(Long userId, String action, LocalDateTime startDate);
+    Long countBadgeCount(Long userId, String action);
 
     @Query(value =
             "select 1 " +

--- a/src/main/java/com/mople/notification/service/NotificationSendService.java
+++ b/src/main/java/com/mople/notification/service/NotificationSendService.java
@@ -47,8 +47,7 @@ public class NotificationSendService {
                                 User user = sendRequest.findUserByToken(token);
                                 Long badgeCount = notificationRepository.countBadgeCount(
                                         user.getId(),
-                                        Action.COMPLETE.name(),
-                                        LocalDateTime.now().minusDays(30)
+                                        Action.COMPLETE.name()
                                 );
 
                                 return buildMessage(notify, token, sendRequest, badgeCount);

--- a/src/main/java/com/mople/notification/service/NotificationService.java
+++ b/src/main/java/com/mople/notification/service/NotificationService.java
@@ -1,7 +1,6 @@
 package com.mople.notification.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mople.core.exception.custom.BadRequestException;
 import com.mople.core.exception.custom.CursorException;
 import com.mople.core.exception.custom.ResourceNotFoundException;
 import com.mople.dto.request.notification.topic.PushTopicRequest;
@@ -134,7 +133,7 @@ public class NotificationService {
         List<NotificationResponse> notificationListResponses = NotificationResponse.of(objectMapper, notifications, planMap);
 
         return FlatCursorPageResponse.of(
-                notificationRepository.countBadgeCount(userId, Action.COMPLETE.name(), LocalDateTime.now().minusDays(30)),
+                notificationRepository.countBadgeCount(userId, Action.COMPLETE.name()),
                 buildNotificationCursorPage(size, notificationListResponses)
         );
     }
@@ -179,24 +178,5 @@ public class NotificationService {
         notificationRepository
                 .getUserNotificationList(user.getId(), Action.COMPLETE)
                 .forEach(Notification::updateReadAt);
-    }
-
-    @Transactional
-    public void readSingleNotification(Long userId, Long notificationId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException(NOT_USER));
-
-        Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_NOTIFY));
-
-        validateNotification(user.getId(), notification);
-
-        notification.updateReadAt();
-    }
-
-    private void validateNotification(Long userId, Notification notification) {
-        if (!notification.getUser().getId().equals(userId)) {
-            throw new BadRequestException(NOT_OWNER_OF_NOTIFICATION);
-        }
     }
 }

--- a/src/main/java/com/mople/notification/utils/NotifySendRequestFactory.java
+++ b/src/main/java/com/mople/notification/utils/NotifySendRequestFactory.java
@@ -16,7 +16,7 @@ public class NotifySendRequestFactory {
     private final NotificationUserReader userReader;
     private final PushTokenReader tokenReader;
 
-    public NotifySendRequest getMeetPushToken(Long triggeredBy, Long meetId, PushTopic pushTopic) {
+    public NotifySendRequest getMeetPushTokens(Long triggeredBy, Long meetId, PushTopic pushTopic) {
 
         List<User> allUser = userReader.findMeetAllUser(triggeredBy, meetId);
         List<Long> users = tokenReader.findAllTokenId(userReader.findUserIds(triggeredBy, allUser), pushTopic);
@@ -27,7 +27,7 @@ public class NotifySendRequestFactory {
         );
     }
 
-    public NotifySendRequest getPlanPushToken(Long triggeredBy, Long planId, PushTopic pushTopic) {
+    public NotifySendRequest getPlanPushTokens(Long triggeredBy, Long planId, PushTopic pushTopic) {
 
         List<User> allUser = userReader.findPlanUsers(triggeredBy, planId);
         List<Long> users = tokenReader.findAllTokenId(userReader.findUserIds(triggeredBy, allUser), pushTopic);
@@ -38,7 +38,7 @@ public class NotifySendRequestFactory {
         );
     }
 
-    public NotifySendRequest getPlanRemindToken(Long planId, PushTopic pushTopic) {
+    public NotifySendRequest getPlanPushTokensAll(Long planId, PushTopic pushTopic) {
 
         List<User> allUser = userReader.findAllPlanUser(planId);
         List<Long> users = tokenReader.findAllTokenId(userReader.findAllUserId(allUser), pushTopic);
@@ -49,7 +49,7 @@ public class NotifySendRequestFactory {
         );
     }
 
-    public NotifySendRequest getReviewCreatorPushToken(Long creatorId, PushTopic pushTopic) {
+    public NotifySendRequest getCreatorPushToken(Long creatorId, PushTopic pushTopic) {
 
         List<User> allUser = userReader.findAllReviewCreatorUser(creatorId);
         List<Long> users = tokenReader.findAllTokenId(userReader.findAllUserId(allUser), pushTopic);
@@ -60,10 +60,10 @@ public class NotifySendRequestFactory {
         );
     }
 
-    public NotifySendRequest getReviewPushToken(Long creatorId, Long reviewId, PushTopic pushTopic) {
+    public NotifySendRequest getReviewPushToken(Long triggeredBy, Long reviewId, PushTopic pushTopic) {
 
-        List<User> allUser = userReader.findAllReviewUser(creatorId, reviewId);
-        List<Long> users = tokenReader.findAllTokenId(userReader.findUserIds(creatorId, allUser), pushTopic);
+        List<User> allUser = userReader.findAllReviewUser(triggeredBy, reviewId);
+        List<Long> users = tokenReader.findAllTokenId(userReader.findUserIds(triggeredBy, allUser), pushTopic);
 
         return new NotifySendRequest(
                 allUser,

--- a/src/main/java/com/mople/user/controller/UserController.java
+++ b/src/main/java/com/mople/user/controller/UserController.java
@@ -1,9 +1,9 @@
 package com.mople.user.controller;
 
 import com.mople.core.annotation.auth.SignUser;
+import com.mople.dto.client.UserClientResponse;
 import com.mople.dto.request.user.AuthUserRequest;
 import com.mople.dto.request.user.UserInfoRequest;
-import com.mople.dto.response.user.UserInfo;
 import com.mople.user.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,7 +29,7 @@ public class UserController {
             description = "유저 정보를 반환합니다."
     )
     @GetMapping("/info")
-    public ResponseEntity<UserInfo> getMyInfo(
+    public ResponseEntity<UserClientResponse> getMyInfo(
             @Parameter(hidden = true) @SignUser AuthUserRequest user
     ) {
         return ResponseEntity.ok(userService.getInfo(user.id()));
@@ -40,7 +40,7 @@ public class UserController {
             description = "DB에 저장된 유저 정보를 갱신합니다."
     )
     @PatchMapping("/info")
-    public ResponseEntity<UserInfo> updateInfo(
+    public ResponseEntity<UserClientResponse> updateInfo(
             @Parameter(hidden = true) @SignUser AuthUserRequest user,
             @Valid @RequestBody UserInfoRequest userInfoRequest
     ) {


### PR DESCRIPTION
# PlanCreate 알림 대상 수정, 알림 만료일 추가, commentLike 복합키 설정
---
## 1. PlanCreate 알림 대상 수정
- `plan create` 타입에서 알림 대상을 `meetMember` 로 수정했습니다! 

---
## 2. 알림 만료일(30일) 추가
- `Notification` 엔티티의 `expiredAt` 필드 설정을 `plusDays(30)` 으로 설정하였습니다!
- `notification list` 를 불러올 때, 만료일을 기준으로 가져왔고 각 `notificationResponse` 에 `readAt` 을 기준으로 `isRead` 필드를 추가했습니다.
  (알림 읽음/안읽음 처리를 서버에서 하도록 하였습니다. 😊)
  (응답값에서 `totalCount` 는 리스트 개수가 아닌 읽지 않은 새로운 알람의 개수입니다.)
- `badgeCount` 도 기존대로 `UserController` 에서 유저 정보를 가져올 때 동적으로 가져와 응답값에 포함해주었습니다. (클라이언트 요청)
- 아마 기존 `notification` 에서 만료일을 재설정 하는 DB 마이그레이션 작업이 필요할 것 같습니다!
```
UPDATE notification 
SET expired_at = send_at + interval '30 days' 
WHERE expired_at > now() + interval '1 year';
```
-  (approve 하시면 배포 후 제가 추가할게용)
----
## 3. `commentLike` 복합키 설정
-` CommentLike` 엔티티의 기본 키를 기존 `id` 에서  `(commentId, userId)` 복합키로 변경하였습니다.
변경 이유  
- `CommentLike` 는 유저와 댓글 관계 테이블로 id 자체는 의미가 없고 조합 자체가 유니크 키이므로 별도의 id가 불필요하다고 생각했습니다
- 중복 방지를 DB 레벨에서 강제하여 데이터 무결성 확보할 수 있습니다!
- 부하테스트도 다시 진행해서 오류율 0% 확인했습니다 !!!
```
ALTER TABLE comment_like DROP COLUMN id;
ALTER TABLE comment_like ADD PRIMARY KEY (comment_id, user_id);
```
- (approve 하면 배포 후 제가 추가할게용)
---

알림 만료일도 테스트 전부 하였습니다 !! 
복합키를 고민만 하다가 이번에 적용해봤습니다... !! 
궁금하신 점이나 의논할 부분 있으시면 언제든지 남겨주세요 😊 항상 감사합니다 대영님 !! 🤗🤗

