### PR TITLE
Refactor/cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,12 @@ dependencies {
 
     implementation(libs.logstash.logback.encoder) // Logstash Logback Encoder (로그를 JSON 형태로 변환)
 
+    implementation(libs.spring.boot.starter.cache) // 캐시 추상화
+    implementation(libs.caffeine)  // Caffeine 로컬 캐시 구현체
+
+    implementation(libs.spring.boot.starter.actuator)  // actuator
+    implementation(libs.micrometer.registry.prometheus)  // prometheus
+
     implementation(libs.firebase.admin) // io.netty 4.1.115 미만 windows dos 공격 취약점 spring netty 4.1.115 이상 지원할 때 변경 - spring 3.4.0에서 해결
 
     implementation(libs.datafaker) // test dummy

--- a/gradle/libs.toml
+++ b/gradle/libs.toml
@@ -86,6 +86,12 @@ jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-ap
 datasource-proxy = { module = "net.ttddyy:datasource-proxy", version.ref = "datasource-proxy" }
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logback-encoder" }
 
+spring-boot-starter-cache = { module = "org.springframework.boot:spring-boot-starter-cache" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }
+
+spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
+micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
+
 firebase-admin = { module = "com.google.firebase:firebase-admin", version.ref = "firebase" }
 
 datafaker = { module = "net.datafaker:datafaker", version.ref = "data-faker" }

--- a/src/main/java/com/mople/core/annotation/cache/InvalidateCache.java
+++ b/src/main/java/com/mople/core/annotation/cache/InvalidateCache.java
@@ -1,0 +1,13 @@
+package com.mople.core.annotation.cache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InvalidateCache {
+    String cacheName();
+    String[] keys();
+}

--- a/src/main/java/com/mople/core/aspect/InvalidateCacheAspect.java
+++ b/src/main/java/com/mople/core/aspect/InvalidateCacheAspect.java
@@ -1,0 +1,89 @@
+package com.mople.core.aspect;
+
+import com.mople.core.annotation.cache.InvalidateCache;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.context.expression.MethodBasedEvaluationContext;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.mople.global.utils.transaction.AfterCommit.afterCommit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class InvalidateCacheAspect {
+
+    private final CacheManager cacheManager;
+    private final ApplicationContext applicationContext;
+
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+    private final ParameterNameDiscoverer discoverer = new DefaultParameterNameDiscoverer();
+
+    @AfterReturning(pointcut = "@annotation(invalidate)", returning = "ret")
+    public void scheduleEvict(JoinPoint joinPoint, InvalidateCache invalidate, Object ret) {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        MethodBasedEvaluationContext context = new MethodBasedEvaluationContext(joinPoint.getTarget(), method, joinPoint.getArgs(), discoverer);
+
+        context.setBeanResolver(new BeanFactoryResolver(applicationContext));
+
+        HashSet<Object> keys = new HashSet<>();
+        for (String key : invalidate.keys()) {
+            if (key == null || key.isBlank()) {
+                continue;
+            }
+
+            Object value = parser.parseExpression(key).getValue(context);
+            collectKeys(value, keys);
+        }
+
+        if (keys.isEmpty()) {
+            return;
+        }
+
+        String cacheName = invalidate.cacheName();
+        Cache cache = cacheManager.getCache(cacheName);
+
+        if (cache == null) {
+            return;
+        }
+
+        Runnable evictTask = () -> keys.forEach(cache::evictIfPresent);
+
+        afterCommit(evictTask);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void collectKeys(Object value, Set<Object> keys) {
+        if (value == null) {
+            return;
+        }
+
+        if (value instanceof Iterable<?> iterable) {
+            iterable.forEach(keys::add);
+            return;
+        }
+        if (value.getClass().isArray()) {
+            for (int i = 0; i < Array.getLength(value); i++) {
+                keys.add(Array.get(value, i));
+            }
+            return;
+        }
+
+        keys.add(value);
+    }
+}

--- a/src/main/java/com/mople/core/config/CacheConfig.java
+++ b/src/main/java/com/mople/core/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package com.mople.core.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.mople.core.config.component.CacheSpecsConfig;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@EnableCaching
+@EnableConfigurationProperties(CacheSpecsConfig.class)
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(CacheSpecsConfig properties) {
+        CaffeineCache homeViewPlan = new CaffeineCache(
+                "homeViewPlan",
+                Caffeine.from(properties.homeViewPlan()).recordStats().build()
+        );
+
+        SimpleCacheManager manager = new SimpleCacheManager();
+        manager.setCaches(List.of(homeViewPlan));
+        return manager;
+    }
+}

--- a/src/main/java/com/mople/core/config/component/CacheSpecsConfig.java
+++ b/src/main/java/com/mople/core/config/component/CacheSpecsConfig.java
@@ -1,0 +1,9 @@
+package com.mople.core.config.component;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cache.caffeine.spec")
+public record  CacheSpecsConfig(
+        String homeViewPlan
+) {
+}

--- a/src/main/java/com/mople/meet/controller/InviteController.java
+++ b/src/main/java/com/mople/meet/controller/InviteController.java
@@ -1,6 +1,6 @@
 package com.mople.meet.controller;
 
-import com.mople.meet.service.MeetService;
+import com.mople.meet.service.meet.MeetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/mople/meet/controller/MeetController.java
+++ b/src/main/java/com/mople/meet/controller/MeetController.java
@@ -9,7 +9,7 @@ import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
 import com.mople.dto.response.pagination.CursorPageResponse;
 import com.mople.dto.response.pagination.FlatCursorPageResponse;
-import com.mople.meet.service.MeetService;
+import com.mople.meet.service.meet.MeetService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/com/mople/meet/repository/MeetMemberRepository.java
+++ b/src/main/java/com/mople/meet/repository/MeetMemberRepository.java
@@ -37,4 +37,7 @@ public interface MeetMemberRepository extends JpaRepository<MeetMember, Long> {
             "        and m.userId = :userId "
     )
     void deleteByMeetIdAndUserId(Long meetId, Long userId);
+
+    @Query("select m.userId from MeetMember m where m.meetId = :meetId")
+    List<Long> findUserIdsByMeetId(Long meetId);
 }

--- a/src/main/java/com/mople/meet/repository/plan/PlanParticipantRepository.java
+++ b/src/main/java/com/mople/meet/repository/plan/PlanParticipantRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface PlanParticipantRepository extends JpaRepository<PlanParticipant, Long> {
 
     boolean existsByPlanIdAndUserId(Long planId, Long userId);
@@ -44,4 +46,7 @@ public interface PlanParticipantRepository extends JpaRepository<PlanParticipant
             "      where p.reviewId = :reviewId "
     )
     void deleteByReviewId(Long reviewId);
+
+    @Query("select p.userId from PlanParticipant p where p.planId = :planId")
+    List<Long> findUserIdsByPlanId(Long planId);
 }

--- a/src/main/java/com/mople/meet/service/meet/MeetRemoveService.java
+++ b/src/main/java/com/mople/meet/service/meet/MeetRemoveService.java
@@ -1,0 +1,53 @@
+package com.mople.meet.service.meet;
+
+import com.mople.core.annotation.cache.InvalidateCache;
+import com.mople.core.exception.custom.ConcurrencyConflictException;
+import com.mople.entity.meet.Meet;
+import com.mople.meet.repository.MeetMemberRepository;
+import com.mople.meet.repository.MeetRepository;
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.StaleObjectStateException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.mople.global.enums.ExceptionReturnCode.REQUEST_CONFLICT;
+
+@Service
+@RequiredArgsConstructor
+public class MeetRemoveService {
+
+    private final MeetRepository meetRepository;
+    private final MeetMemberRepository memberRepository;
+
+    @InvalidateCache(
+            cacheName = "homeViewPlan",
+            keys = {"@meetMemberRepository.findUserIdsByMeetId(#meet.id)"}
+    )
+    @Transactional
+    public void removeMeetAsCreator(Meet meet, Long userId) {
+        meet.softDelete(userId);
+
+        try {
+            meetRepository.flush();
+
+        } catch (
+                OptimisticLockException
+                | OptimisticLockingFailureException
+                | StaleObjectStateException e
+        ) {
+            long currentVersion = meetRepository.findVersion(meet.getId());
+            throw new ConcurrencyConflictException(REQUEST_CONFLICT, currentVersion);
+        }
+    }
+
+    @InvalidateCache(
+            cacheName = "homeViewPlan",
+            keys = {"#userId"}
+    )
+    @Transactional
+    public void removeMeetAsMember(Long meetId, Long userId) {
+        memberRepository.deleteByMeetIdAndUserId(meetId, userId);
+    }
+}

--- a/src/main/java/com/mople/meet/service/meet/MeetService.java
+++ b/src/main/java/com/mople/meet/service/meet/MeetService.java
@@ -1,4 +1,4 @@
-package com.mople.meet.service;
+package com.mople.meet.service.meet;
 
 import com.mople.core.exception.custom.*;
 import com.mople.dto.client.MeetClientResponse;
@@ -57,6 +57,7 @@ public class MeetService {
     private final MeetMemberRepositorySupport meetMemberRepositorySupport;
     private final UserRepository userRepository;
     private final OutboxService outboxService;
+    private final MeetRemoveService meetRemoveService;
     private final EntityReader reader;
 
     private final String inviteUrl;
@@ -69,6 +70,7 @@ public class MeetService {
             MeetMemberRepositorySupport meetMemberRepositorySupport,
             UserRepository userRepository,
             OutboxService outboxService,
+            MeetRemoveService meetRemoveService,
             EntityReader reader,
             @Value("${mople.url}") String inviteUrl
     ) {
@@ -79,6 +81,7 @@ public class MeetService {
         this.meetMemberRepositorySupport = meetMemberRepositorySupport;
         this.userRepository = userRepository;
         this.outboxService = outboxService;
+        this.meetRemoveService = meetRemoveService;
         this.reader = reader;
         this.inviteUrl = inviteUrl;
     }
@@ -280,32 +283,19 @@ public class MeetService {
         }
 
         if (meet.matchCreator(userId)) {
-
-            meet.softDelete(userId);
-
-            try {
-                meetRepository.flush();
-
-            } catch (
-                    OptimisticLockException
-                    | OptimisticLockingFailureException
-                    | StaleObjectStateException e
-            ) {
-                long currentVersion = meetRepository.findVersion(meet.getId());
-                throw new ConcurrencyConflictException(REQUEST_CONFLICT, currentVersion);
-            }
+            meetRemoveService.removeMeetAsCreator(meet, userId);
 
             MeetSoftDeletedEvent deletedEvent = MeetSoftDeletedEvent.builder()
-                    .meetId(meetId)
+                    .meetId(meet.getId())
                     .meetDeletedBy(userId)
                     .build();
 
-            outboxService.save(MEET_SOFT_DELETED, MEET, meetId, deletedEvent);
+            outboxService.save(MEET_SOFT_DELETED, MEET, meet.getId(), deletedEvent);
 
             return;
         }
 
-        meetMemberRepository.deleteByMeetIdAndUserId(meetId, userId);
+        meetRemoveService.removeMeetAsMember(meetId, userId);
 
         MeetLeftEvent leftEvent = MeetLeftEvent.builder()
                 .meetId(meetId)
@@ -317,6 +307,7 @@ public class MeetService {
 
     @Transactional
     public String createInvite(Long userId, Long meetId) {
+
         reader.findUser(userId);
         reader.findMeet(meetId);
 

--- a/src/main/java/com/mople/meet/service/plan/PlanService.java
+++ b/src/main/java/com/mople/meet/service/plan/PlanService.java
@@ -42,6 +42,7 @@ import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 
 import org.hibernate.StaleObjectStateException;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -81,6 +82,7 @@ public class PlanService {
     private final EntityReader reader;
     private final OutboxService outboxService;
 
+    @Cacheable(cacheNames = "homeViewPlan", key = "#userId")
     @Transactional(readOnly = true)
     public PlanHomeViewResponse getPlanView(Long userId) {
         reader.findUser(userId);

--- a/src/main/java/com/mople/meet/service/plan/PlanService.java
+++ b/src/main/java/com/mople/meet/service/plan/PlanService.java
@@ -1,5 +1,6 @@
 package com.mople.meet.service.plan;
 
+import com.mople.core.annotation.cache.InvalidateCache;
 import com.mople.core.exception.custom.*;
 import com.mople.dto.client.PlanClientResponse;
 import com.mople.dto.client.UserRoleClientResponse;
@@ -95,15 +96,16 @@ public class PlanService {
         );
     }
 
+    @InvalidateCache(
+            cacheName = "homeViewPlan",
+            keys = {"#userId"}
+    )
     @Transactional
-    public PlanClientResponse createPlan(
-            Long creatorId,
-            PlanCreateRequest request
-    ) {
-        var user = reader.findUser(creatorId);
+    public PlanClientResponse createPlan(Long userId, PlanCreateRequest request) {
+        var user = reader.findUser(userId);
         var meet = reader.findMeet(request.meetId());
 
-        if (!memberRepository.existsByMeetIdAndUserId(request.meetId(), creatorId)) {
+        if (!memberRepository.existsByMeetIdAndUserId(request.meetId(), userId)) {
             throw new AuthException(NOT_CREATOR);
         }
 
@@ -218,6 +220,10 @@ public class PlanService {
                 commentRepositorySupport.countComment(plan.getId()));
     }
 
+    @InvalidateCache(
+            cacheName = "homeViewPlan",
+            keys = {"@planParticipantRepository.findUserIdsByPlanId(#planId)"}
+    )
     @Transactional
     public void deletePlan(Long userId, Long planId) {
         reader.findUser(userId);
@@ -408,6 +414,10 @@ public class PlanService {
         }
     }
 
+    @InvalidateCache(
+            cacheName = "homeViewPlan",
+            keys = {"#userId"}
+    )
     @Transactional
     public void joinPlanParticipant(Long userId, Long planId) {
         reader.findUser(userId);
@@ -425,6 +435,10 @@ public class PlanService {
         planParticipantRepository.save(planParticipant);
     }
 
+    @InvalidateCache(
+            cacheName = "homeViewPlan",
+            keys = {"#userId"}
+    )
     @Transactional
     public void deletePlanParticipant(Long userId, Long planId) {
         reader.findPlan(planId);


### PR DESCRIPTION
HomeView 대시보드에서 카페인 캐시를 적용했습니다..!

간단한 대시보드라서 TTL 60초로만 유지되도록 했습니다. 만약에 정합성이 더 필요한 것 같으면 간단하게 캐시 무효화 추가할 생각입니다..!!
그리고 actuator 사용해서 프로메테우스로 캐시 히트율 등 간단한 지표 시각화 할 수 있도록 구상하였습니다...!!

========

 10.14.화 추가

`@InvalidateCache` 어노테이션 추가해서, AOP 로 캐시 무효화 하는 로직 구현했습니다..!!
```
@InvalidateCache(
            cacheName = "homeViewPlan",
            keys = {"@meetMemberRepository.findUserIdsByMeetId(#meet.id)"}
)
```
캐시 이름 `cacheName`과 키 배열 `keys` 을 인자로 받아
트랜잭션 커밋 이후 해당 캐시 엔트리를 자동으로 제거하도록 구현했습니다.

`@AfterReturning` 시점에서 `SpEL`을 평가해, 컬렉션/배열 등도 일괄 무효화되도록 처리했습니다!

그리고 `MeetRemoveService` 추가했습니다..!
기존 `MeetService.removeMeet()` 에서 모임 삭제 / 탈퇴 로직이 함께 처리되어 있었는데, 각 케이스별로 캐시 무효화 대상이 다르기 때문에 책임을 분리했습니다.

같은 빈 내에서 호출 문제가 발생하는데,  트랜잭션은 `Required_new` 로
프록시는 `((MeetService) AopContext.currentProxy())` 로 자기 호출 문제를 해결할 수 있지만 
기본적으로 스프링 AOP가 프록시를 노출하지 않도록 되어있는 전역 설정을 `@EnableAspectJAutoProxy(exposeProxy = true)`로 바꿔야 합니다. 
하지만 이 문제 하나 때문에 전역 설정을 바꾸는 것이 걸려서, 다른 클래스로 분리하여 트랜잭션과 aop 문제를 해결했습니다...!

캐시 무효화는 일정 생성/삭제/참여/떠나기 와 모임 삭제/떠나기 에 적용했습니다 !! 모두 테스트 확인했습니다 🫡🫡