### PR TITLE
feat: OutboxEvent 를 비동기 처리하도록 변경

### DIFF
--- a/src/main/java/com/mople/outbox/service/OutboxPublisher.java
+++ b/src/main/java/com/mople/outbox/service/OutboxPublisher.java
@@ -1,6 +1,7 @@
 package com.mople.outbox.service;
 
 import com.mople.entity.event.OutboxEvent;
+import com.mople.global.logging.logger.BusinessLogicLogger;
 import com.mople.outbox.repository.OutboxEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,6 +9,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +18,8 @@ public class OutboxPublisher {
 
     private final OutboxProcessor processor;
     private final OutboxEventRepository outboxEventRepository;
+    private final BusinessLogicLogger logicLogger;
+    private final Executor outboxExecutor;
 
     @Value("${outbox.batch-size}")
     private int batchSize;
@@ -26,8 +31,18 @@ public class OutboxPublisher {
     public void publishBatch() {
         List<OutboxEvent> outboxEvents = outboxEventRepository.lockNextBatch(batchSize, leaseSec);
 
-        for (OutboxEvent event : outboxEvents) {
-            processor.processOne(event);
-        }
+        List<CompletableFuture<Void>> futures = outboxEvents.stream()
+                .map(event -> CompletableFuture.runAsync(
+                        () -> processor.processOne(event),
+                        outboxExecutor
+                ).exceptionally(ex -> {
+                    logicLogger.logError("OutboxEvent 처리 실패");
+                    return null;
+                }))
+                .toList();
+
+        CompletableFuture
+                .allOf(futures.toArray(new CompletableFuture[0]))
+                .join();
     }
 }


### PR DESCRIPTION
비동기 기반 Outbox 처리!
---
`config`를 보다가 실행 스레드 설정을 발견하고,
기존에는 100개의 이벤트를 폴링하여 단일 스레드로  동기 처리하던 구조에서
`CompletableFuture`와 `ThreadPoolTaskExecutor`를 활용해 병렬 구조로 전환했습니다!

`@Async` 대신 `CompletableFuture` 를 사용한 이유는
우선 Outbox는 이벤트 단위로 예외, 재시도, 트랜잭션을 독립적으로 관리해야 합니다.
`CompletableFuture`는 코드 내에서 비동기 흐름을 세밀하게 제어할 수 있어서 
배치 단위 병렬 처리와 실패 격리 로직을 구현하기에 적합하다고 생각했습니다...!

반면 `@Async`는 스프링 프록시로 동작하기 때문에 호출한 뒤 제어권을 잃어 `CompletableFuture` 처럼 세밀한 제어가 어려웠습니다 🥲
예외도 `AsyncUncaughtExceptionHandler`를 통해서만 처리해야 합니다,,

---
테스트로 확인했습니다 대영님!!! 😁