### PR TITLE
Feat/meet left

### DIFF
--- a/src/main/java/com/mople/dto/response/meet/PlanPageResponse.java
+++ b/src/main/java/com/mople/dto/response/meet/PlanPageResponse.java
@@ -8,6 +8,7 @@ public record PlanPageResponse(
         String meetImage,
         Long planId,
         String planName,
+        Long creatorId,
         LocalDateTime planTime,
         Integer planParticipants,
         String weatherIcon,

--- a/src/main/java/com/mople/dto/response/meet/ReviewPageResponse.java
+++ b/src/main/java/com/mople/dto/response/meet/ReviewPageResponse.java
@@ -8,6 +8,7 @@ public record ReviewPageResponse(
         String meetImage,
         Long reviewId,
         String reviewName,
+        Long creatorId,
         LocalDateTime reviewTime,
         Integer reviewParticipants,
         String weatherIcon,

--- a/src/main/java/com/mople/global/event/handler/domain/impl/comment/notifier/CommentMentionAddedNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/comment/notifier/CommentMentionAddedNotifier.java
@@ -4,17 +4,12 @@ import com.mople.core.exception.custom.NonRetryableOutboxException;
 import com.mople.dto.event.data.domain.comment.CommentMentionAddedEvent;
 import com.mople.dto.event.data.domain.global.NotifyRequestedEvent;
 import com.mople.dto.event.data.notify.comment.CommentMentionNotifyEvent;
-import com.mople.entity.meet.Meet;
-import com.mople.entity.meet.plan.MeetPlan;
-import com.mople.entity.meet.review.PlanReview;
 import com.mople.entity.notification.Notification;
 import com.mople.entity.user.User;
 import com.mople.global.enums.ExceptionReturnCode;
 import com.mople.global.enums.Status;
 import com.mople.global.event.handler.domain.DomainEventHandler;
-import com.mople.meet.repository.MeetRepository;
-import com.mople.meet.repository.plan.MeetPlanRepository;
-import com.mople.meet.repository.review.PlanReviewRepository;
+import com.mople.global.event.service.PostContextFinder;
 import com.mople.notification.reader.NotificationUserReader;
 import com.mople.notification.repository.NotificationRepository;
 import com.mople.outbox.service.OutboxService;
@@ -31,9 +26,7 @@ import static com.mople.global.enums.event.EventTypeNames.NOTIFY_REQUESTED;
 @RequiredArgsConstructor
 public class CommentMentionAddedNotifier implements DomainEventHandler<CommentMentionAddedEvent> {
 
-    private final MeetRepository meetRepository;
-    private final MeetPlanRepository planRepository;
-    private final PlanReviewRepository reviewRepository;
+    private final PostContextFinder contextFinder;
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
 
@@ -47,85 +40,57 @@ public class CommentMentionAddedNotifier implements DomainEventHandler<CommentMe
 
     @Override
     public void handle(CommentMentionAddedEvent event) {
-        List<Long> filteredTargetIds = userReader.findUpdatedMentionedUsers(
-                event.originMentions(), event.commentWriterId(), event.commentId()
+        PostContextFinder.PostContext postContext = contextFinder.resolve(event.postId());
+        List<Long> targetIds = userReader.findUpdatedMentionedUsers(
+                event.originMentions(), event.commentWriterId(), event.commentId(), postContext.getMeet().getId()
         );
 
-        if (filteredTargetIds.isEmpty()) {
+        if (targetIds.isEmpty()) {
             return;
         }
 
-        User user = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_USER));
+        User sender = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_USER));
 
-        if (planRepository.existsByIdAndStatus(event.postId(), Status.ACTIVE)) {
-            MeetPlan plan = planRepository.findByIdAndStatus(event.postId(), Status.ACTIVE)
-                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_PLAN));
+        CommentMentionNotifyEvent.CommentMentionNotifyEventBuilder eventBuilder = CommentMentionNotifyEvent.builder()
+                .meetName(postContext.getMeet().getName())
+                .senderNickname(sender.getNickname());
 
-            Meet meet = meetRepository.findByIdAndStatus(plan.getMeetId(), Status.ACTIVE)
-                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
-
-            CommentMentionNotifyEvent notifyEvent = CommentMentionNotifyEvent.builder()
-                    .meetName(meet.getName())
-                    .planId(plan.getId())
-                    .senderNickname(user.getNickname())
-                    .build();
-
-            List<Long> notificationIds = notificationRepository.saveAll(
-                            filteredTargetIds.stream()
-                                    .map(targetId ->
-                                            Notification.builder()
-                                                    .type(notifyEvent.notifyType())
-                                                    .meetId(meet.getId())
-                                                    .planId(plan.getId())
-                                                    .payload(notifyEvent.payload())
-                                                    .userId(targetId)
-                                                    .build()
-                                    )
-                                    .toList()
-                    ).stream()
-                    .map(Notification::getId).toList();
-
-            outboxService.save(
-                    NOTIFY_REQUESTED,
-                    POST,
-                    plan.getId(),
-                    new NotifyRequestedEvent(notifyEvent, notificationIds)
-            );
-            return;
+        if (postContext.isPlan()) {
+            eventBuilder.planId(postContext.getPlanId());
+        }
+        if (postContext.isReview()) {
+            eventBuilder.reviewId(postContext.getReviewId());
         }
 
-        PlanReview review = reviewRepository.findByPlanIdAndStatus(event.postId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_REVIEW));
+        CommentMentionNotifyEvent notifyEvent = eventBuilder.build();
 
-        Meet meet = meetRepository.findByIdAndStatus(review.getMeetId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
+        List<Notification> notifications = targetIds.stream()
+                .map(targetId -> {
+                    Notification.NotificationBuilder notificationBuilder = Notification.builder()
+                            .type(notifyEvent.notifyType())
+                            .meetId(postContext.getMeet().getId())
+                            .payload(notifyEvent.payload())
+                            .userId(targetId);
 
-        CommentMentionNotifyEvent notifyEvent = CommentMentionNotifyEvent.builder()
-                .meetName(meet.getName())
-                .reviewId(review.getId())
-                .senderNickname(user.getNickname())
-                .build();
+                    if (postContext.isPlan()) {
+                        notificationBuilder.planId(postContext.getPlanId());
+                    }
+                    if (postContext.isReview()) {
+                        notificationBuilder.reviewId(postContext.getReviewId());
+                    }
 
-        List<Long> notificationIds = notificationRepository.saveAll(
-                        filteredTargetIds.stream()
-                                .map(targetId ->
-                                        Notification.builder()
-                                                .type(notifyEvent.notifyType())
-                                                .meetId(meet.getId())
-                                                .reviewId(review.getId())
-                                                .payload(notifyEvent.payload())
-                                                .userId(targetId)
-                                                .build()
-                                )
-                                .toList()
-                ).stream()
-                .map(Notification::getId).toList();
+                    return notificationBuilder.build();
+                })
+                .toList();
+
+        List<Long> notificationIds = notificationRepository.saveAll(notifications)
+                .stream().map(Notification::getId).toList();
 
         outboxService.save(
                 NOTIFY_REQUESTED,
                 POST,
-                review.getPlanId(),
+                postContext.getPlanId(),
                 new NotifyRequestedEvent(notifyEvent, notificationIds)
         );
     }

--- a/src/main/java/com/mople/global/event/handler/domain/impl/comment/notifier/CommentMentionNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/comment/notifier/CommentMentionNotifier.java
@@ -4,17 +4,12 @@ import com.mople.core.exception.custom.NonRetryableOutboxException;
 import com.mople.dto.event.data.domain.comment.CommentCreatedEvent;
 import com.mople.dto.event.data.domain.global.NotifyRequestedEvent;
 import com.mople.dto.event.data.notify.comment.CommentMentionNotifyEvent;
-import com.mople.entity.meet.Meet;
-import com.mople.entity.meet.plan.MeetPlan;
-import com.mople.entity.meet.review.PlanReview;
 import com.mople.entity.notification.Notification;
 import com.mople.entity.user.User;
 import com.mople.global.enums.ExceptionReturnCode;
 import com.mople.global.enums.Status;
 import com.mople.global.event.handler.domain.DomainEventHandler;
-import com.mople.meet.repository.MeetRepository;
-import com.mople.meet.repository.plan.MeetPlanRepository;
-import com.mople.meet.repository.review.PlanReviewRepository;
+import com.mople.global.event.service.PostContextFinder;
 import com.mople.notification.reader.NotificationUserReader;
 import com.mople.notification.repository.NotificationRepository;
 import com.mople.outbox.service.OutboxService;
@@ -31,9 +26,7 @@ import static com.mople.global.enums.event.EventTypeNames.NOTIFY_REQUESTED;
 @RequiredArgsConstructor
 public class CommentMentionNotifier implements DomainEventHandler<CommentCreatedEvent> {
 
-    private final MeetRepository meetRepository;
-    private final MeetPlanRepository planRepository;
-    private final PlanReviewRepository reviewRepository;
+    private final PostContextFinder contextFinder;
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
 
@@ -51,83 +44,59 @@ public class CommentMentionNotifier implements DomainEventHandler<CommentCreated
             return;
         }
 
-        List<Long> targetIds = userReader.findCreatedMentionedUsers(event.commentWriterId(), event.commentId());
+        PostContextFinder.PostContext postContext = contextFinder.resolve(event.postId());
+        List<Long> targetIds = userReader.findCreatedMentionedUsers(
+                event.commentWriterId(),
+                event.commentId(),
+                postContext.getMeet().getId()
+        );
 
         if (targetIds.isEmpty()) {
             return;
         }
 
-        User user = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
+        User sender = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
                 .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_USER));
 
-        if (planRepository.existsByIdAndStatus(event.postId(), Status.ACTIVE)) {
-            MeetPlan plan = planRepository.findByIdAndStatus(event.postId(), Status.ACTIVE)
-                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_PLAN));
+        CommentMentionNotifyEvent.CommentMentionNotifyEventBuilder eventBuilder = CommentMentionNotifyEvent.builder()
+                .meetName(postContext.getMeet().getName())
+                .senderNickname(sender.getNickname());
 
-            Meet meet = meetRepository.findByIdAndStatus(plan.getMeetId(), Status.ACTIVE)
-                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
-
-            CommentMentionNotifyEvent notifyEvent = CommentMentionNotifyEvent.builder()
-                    .meetName(meet.getName())
-                    .planId(plan.getId())
-                    .senderNickname(user.getNickname())
-                    .build();
-
-            List<Long> notificationIds = notificationRepository.saveAll(
-                            targetIds.stream()
-                                    .map(targetId ->
-                                            Notification.builder()
-                                                    .type(notifyEvent.notifyType())
-                                                    .meetId(meet.getId())
-                                                    .planId(plan.getId())
-                                                    .payload(notifyEvent.payload())
-                                                    .userId(targetId)
-                                                    .build()
-                                    )
-                                    .toList()
-                    ).stream()
-                    .map(Notification::getId).toList();
-
-            outboxService.save(
-                    NOTIFY_REQUESTED,
-                    POST,
-                    plan.getId(),
-                    new NotifyRequestedEvent(notifyEvent, notificationIds)
-            );
-            return;
+        if (postContext.isPlan()) {
+            eventBuilder.planId(postContext.getPlanId());
+        }
+        if (postContext.isReview()) {
+            eventBuilder.reviewId(postContext.getReviewId());
         }
 
-        PlanReview review = reviewRepository.findByPlanIdAndStatus(event.postId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_REVIEW));
+        CommentMentionNotifyEvent notifyEvent = eventBuilder.build();
 
-        Meet meet = meetRepository.findByIdAndStatus(review.getMeetId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
+        List<Notification> notifications = targetIds.stream()
+                .map(targetId -> {
+                    Notification.NotificationBuilder notificationBuilder = Notification.builder()
+                            .type(notifyEvent.notifyType())
+                            .meetId(postContext.getMeet().getId())
+                            .payload(notifyEvent.payload())
+                            .userId(targetId);
 
-        CommentMentionNotifyEvent notifyEvent = CommentMentionNotifyEvent.builder()
-                .meetName(meet.getName())
-                .reviewId(review.getId())
-                .senderNickname(user.getNickname())
-                .build();
+                    if (postContext.isPlan()) {
+                        notificationBuilder.planId(postContext.getPlanId());
+                    }
+                    if (postContext.isReview()) {
+                        notificationBuilder.reviewId(postContext.getReviewId());
+                    }
 
-        List<Long> notificationIds = notificationRepository.saveAll(
-                        targetIds.stream()
-                                .map(targetId ->
-                                        Notification.builder()
-                                                .type(notifyEvent.notifyType())
-                                                .meetId(meet.getId())
-                                                .reviewId(review.getId())
-                                                .payload(notifyEvent.payload())
-                                                .userId(targetId)
-                                                .build()
-                                )
-                                .toList()
-                ).stream()
-                .map(Notification::getId).toList();
+                    return notificationBuilder.build();
+                })
+                .toList();
+
+        List<Long> notificationIds = notificationRepository.saveAll(notifications)
+                .stream().map(Notification::getId).toList();
 
         outboxService.save(
                 NOTIFY_REQUESTED,
                 POST,
-                review.getPlanId(),
+                postContext.getPlanId(),
                 new NotifyRequestedEvent(notifyEvent, notificationIds)
         );
     }

--- a/src/main/java/com/mople/global/event/handler/domain/impl/comment/notifier/CommentReplyNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/comment/notifier/CommentReplyNotifier.java
@@ -4,17 +4,12 @@ import com.mople.core.exception.custom.NonRetryableOutboxException;
 import com.mople.dto.event.data.domain.comment.CommentCreatedEvent;
 import com.mople.dto.event.data.domain.global.NotifyRequestedEvent;
 import com.mople.dto.event.data.notify.comment.CommentReplyNotifyEvent;
-import com.mople.entity.meet.Meet;
-import com.mople.entity.meet.plan.MeetPlan;
-import com.mople.entity.meet.review.PlanReview;
 import com.mople.entity.notification.Notification;
 import com.mople.entity.user.User;
 import com.mople.global.enums.ExceptionReturnCode;
 import com.mople.global.enums.Status;
 import com.mople.global.event.handler.domain.DomainEventHandler;
-import com.mople.meet.repository.MeetRepository;
-import com.mople.meet.repository.plan.MeetPlanRepository;
-import com.mople.meet.repository.review.PlanReviewRepository;
+import com.mople.global.event.service.PostContextFinder;
 import com.mople.notification.reader.NotificationUserReader;
 import com.mople.notification.repository.NotificationRepository;
 import com.mople.outbox.service.OutboxService;
@@ -31,12 +26,9 @@ import static com.mople.global.enums.event.EventTypeNames.NOTIFY_REQUESTED;
 @RequiredArgsConstructor
 public class CommentReplyNotifier implements DomainEventHandler<CommentCreatedEvent> {
 
-    private final MeetRepository meetRepository;
-    private final MeetPlanRepository planRepository;
-    private final PlanReviewRepository reviewRepository;
+    private final PostContextFinder contextFinder;
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
-
     private final NotificationUserReader userReader;
     private final OutboxService outboxService;
 
@@ -51,81 +43,66 @@ public class CommentReplyNotifier implements DomainEventHandler<CommentCreatedEv
             return;
         }
 
-        Long targetId = userReader.findCommentRepliedUserNoWriter(event.commentWriterId(), event.parentId());
+        PostContextFinder.PostContext postContext = contextFinder.resolve(event.postId());
+        Long targetId = userReader.findCommentRepliedUserNoWriter(
+                event.commentWriterId(),
+                event.parentId(),
+                postContext.getMeet().getId()
+        );
 
         if (targetId == null) {
             return;
         }
 
-        User user = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
+        User sender = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
                 .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_USER));
 
         if (event.isExistMention()) {
-            List<Long> mentionedUsers = userReader.findCreatedMentionedUsers(event.commentWriterId(), event.commentId());
+            List<Long> mentionedUsers = userReader.findCreatedMentionedUsers(
+                    event.commentWriterId(),
+                    event.commentId(),
+                    postContext.getMeet().getId()
+            );
 
             if (!mentionedUsers.isEmpty() && mentionedUsers.contains(targetId)) {
                 return;
             }
         }
 
-        if (planRepository.existsByIdAndStatus(event.postId(), Status.ACTIVE)) {
-            MeetPlan plan = planRepository.findByIdAndStatus(event.postId(), Status.ACTIVE)
-                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_PLAN));
+        CommentReplyNotifyEvent.CommentReplyNotifyEventBuilder eventBuilder = CommentReplyNotifyEvent.builder()
+                .meetName(postContext.getMeet().getName())
+                .senderNickname(sender.getNickname());
 
-            Meet meet = meetRepository.findByIdAndStatus(plan.getMeetId(), Status.ACTIVE)
-                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
-
-            CommentReplyNotifyEvent notifyEvent = CommentReplyNotifyEvent.builder()
-                    .meetName(meet.getName())
-                    .planId(plan.getId())
-                    .senderNickname(user.getNickname())
-                    .build();
-
-            Long notificationId = notificationRepository.save(
-                    Notification.builder()
-                            .type(notifyEvent.notifyType())
-                            .meetId(meet.getId())
-                            .planId(plan.getId())
-                            .payload(notifyEvent.payload())
-                            .userId(targetId)
-                            .build()
-            ).getId();
-
-            outboxService.save(
-                    NOTIFY_REQUESTED,
-                    POST,
-                    plan.getId(),
-                    new NotifyRequestedEvent(notifyEvent, List.of(notificationId))
-            );
-            return;
+        if (postContext.isPlan()) {
+            eventBuilder.planId(postContext.getPlanId());
+        }
+        if (postContext.isReview()) {
+            eventBuilder.reviewId(postContext.getReviewId());
         }
 
-        PlanReview review = reviewRepository.findByPlanIdAndStatus(event.postId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_REVIEW));
+        CommentReplyNotifyEvent notifyEvent = eventBuilder.build();
 
-        Meet meet = meetRepository.findByIdAndStatus(review.getMeetId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
+        Notification.NotificationBuilder notificationBuilder = Notification.builder()
+                            .type(notifyEvent.notifyType())
+                            .meetId(postContext.getMeet().getId())
+                            .payload(notifyEvent.payload())
+                            .userId(targetId);
 
-        CommentReplyNotifyEvent notifyEvent = CommentReplyNotifyEvent.builder()
-                .meetName(meet.getName())
-                .reviewId(review.getId())
-                .senderNickname(user.getNickname())
-                .build();
+        if (postContext.isPlan()) {
+            notificationBuilder.planId(postContext.getPlanId());
+        }
+        if (postContext.isReview()) {
+            notificationBuilder.reviewId(postContext.getReviewId());
+        }
 
-        Long notificationId = notificationRepository.save(
-                Notification.builder()
-                        .type(notifyEvent.notifyType())
-                        .meetId(meet.getId())
-                        .reviewId(review.getId())
-                        .payload(notifyEvent.payload())
-                        .userId(targetId)
-                        .build()
-        ).getId();
+        Notification notification = notificationBuilder.build();
+
+        Long notificationId = notificationRepository.save(notification).getId();
 
         outboxService.save(
                 NOTIFY_REQUESTED,
                 POST,
-                review.getPlanId(),
+                postContext.getPlanId(),
                 new NotifyRequestedEvent(notifyEvent, List.of(notificationId))
         );
     }

--- a/src/main/java/com/mople/global/event/handler/domain/impl/meet/MeetLeftPlanParticipantHandler.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/meet/MeetLeftPlanParticipantHandler.java
@@ -1,0 +1,29 @@
+package com.mople.global.event.handler.domain.impl.meet;
+
+import com.mople.dto.event.data.domain.meet.MeetLeftEvent;
+import com.mople.global.event.handler.domain.DomainEventHandler;
+import com.mople.meet.repository.plan.MeetPlanRepository;
+import com.mople.meet.repository.plan.PlanParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MeetLeftPlanParticipantHandler implements DomainEventHandler<MeetLeftEvent> {
+
+    private final MeetPlanRepository planRepository;
+    private final PlanParticipantRepository participantRepository;
+
+    @Override
+    public Class<MeetLeftEvent> getHandledType() {
+        return MeetLeftEvent.class;
+    }
+
+    @Override
+    public void handle(MeetLeftEvent event) {
+        List<Long> planIds = planRepository.findIdsByMeetId(event.meetId());
+        participantRepository.deleteByPlanIdsAndUserId(planIds, event.leaveMemberId());
+    }
+}

--- a/src/main/java/com/mople/global/event/handler/domain/impl/plan/notifier/PlanRemindNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/plan/notifier/PlanRemindNotifier.java
@@ -44,7 +44,7 @@ public class PlanRemindNotifier implements DomainEventHandler<PlanRemindEvent> {
         MeetPlan plan = planRepository.findByIdAndStatus(event.planId(), Status.ACTIVE)
                 .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_PLAN));
 
-        List<Long> targetIds = userReader.findPlanUsersAll(plan.getCreatorId());
+        List<Long> targetIds = userReader.findPlanUsersAll(plan.getId());
 
         if (targetIds.isEmpty()) {
             return;

--- a/src/main/java/com/mople/global/event/handler/domain/impl/review/notifier/ReviewUploadNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/review/notifier/ReviewUploadNotifier.java
@@ -44,7 +44,11 @@ public class ReviewUploadNotifier implements DomainEventHandler<ReviewUploadEven
         PlanReview review = reviewRepository.findByIdAndStatus(event.reviewId(), Status.ACTIVE)
                 .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_REVIEW));
 
-        List<Long> targetIds = userReader.findReviewUsersNoTriggers(event.reviewUpdatedBy(), event.reviewId());
+        List<Long> targetIds = userReader.findReviewUsersNoTriggers(
+                event.reviewUpdatedBy(),
+                event.reviewId(),
+                review.getMeetId()
+        );
 
         if (targetIds.isEmpty()) {
             return;

--- a/src/main/java/com/mople/global/event/service/PostContextFinder.java
+++ b/src/main/java/com/mople/global/event/service/PostContextFinder.java
@@ -1,0 +1,81 @@
+package com.mople.global.event.service;
+
+import com.mople.core.exception.custom.NonRetryableOutboxException;
+import com.mople.entity.meet.Meet;
+import com.mople.entity.meet.plan.MeetPlan;
+import com.mople.entity.meet.review.PlanReview;
+import com.mople.global.enums.ExceptionReturnCode;
+import com.mople.global.enums.Status;
+import com.mople.meet.repository.MeetRepository;
+import com.mople.meet.repository.plan.MeetPlanRepository;
+import com.mople.meet.repository.review.PlanReviewRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class PostContextFinder {
+
+    private final MeetPlanRepository planRepository;
+    private final PlanReviewRepository reviewRepository;
+    private final MeetRepository meetRepository;
+
+    public PostContext resolve(Long postId) {
+        Optional<MeetPlan> planOptional = planRepository.findByIdAndStatus(postId, Status.ACTIVE);
+
+        if (planOptional.isPresent()) {
+            MeetPlan plan = planOptional.get();
+
+            Meet meet = meetRepository.findByIdAndStatus(plan.getMeetId(), Status.ACTIVE)
+                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
+
+            return PostContext.plan(meet, plan);
+        }
+
+        PlanReview review = reviewRepository.findByPlanIdAndStatus(postId, Status.ACTIVE)
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_REVIEW));
+
+        Meet meet = meetRepository.findByIdAndStatus(review.getMeetId(), Status.ACTIVE)
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
+
+        return PostContext.review(meet, review);
+    }
+
+    @Getter
+    public static class PostContext {
+        public enum Type {
+            PLAN, REVIEW
+        }
+
+        private final Type type;
+        private final Meet meet;
+        private final Long planId;
+        private final Long reviewId;
+
+        private PostContext(Type type, Meet meet, Long planId, Long reviewId) {
+            this.type = type;
+            this.meet = meet;
+            this.planId = planId;
+            this.reviewId = reviewId;
+        }
+
+        public static PostContext plan(Meet meet, MeetPlan plan) {
+            return new PostContext(Type.PLAN, meet, plan.getId(), null);
+        }
+
+        public static PostContext review(Meet meet, PlanReview review) {
+            return new PostContext(Type.REVIEW, meet, review.getPlanId(), review.getId());
+        }
+
+        public boolean isPlan()   {
+            return type == Type.PLAN;
+        }
+
+        public boolean isReview() {
+            return type == Type.REVIEW;
+        }
+    }
+}

--- a/src/main/java/com/mople/meet/repository/impl/plan/PlanRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/plan/PlanRepositorySupport.java
@@ -193,6 +193,7 @@ public class PlanRepositorySupport {
                                 meet.meetImage,
                                 plan.id,
                                 plan.name,
+                                plan.creatorId,
                                 plan.planTime,
                                 JPAExpressions
                                         .select(ppAll.count().intValue())
@@ -230,6 +231,7 @@ public class PlanRepositorySupport {
                                 meet.meetImage,
                                 review.id,
                                 review.name,
+                                review.creatorId,
                                 review.planTime,
                                 JPAExpressions
                                         .select(ppAll.count().intValue())

--- a/src/main/java/com/mople/meet/repository/plan/PlanParticipantRepository.java
+++ b/src/main/java/com/mople/meet/repository/plan/PlanParticipantRepository.java
@@ -43,6 +43,14 @@ public interface PlanParticipantRepository extends JpaRepository<PlanParticipant
     @Modifying(flushAutomatically = true)
     @Query(
             "delete from PlanParticipant p " +
+            "      where p.planId in :planIds " +
+            "        and p.userId = :userId "
+    )
+    void deleteByPlanIdsAndUserId(List<Long> planIds, Long userId);
+
+    @Modifying(flushAutomatically = true)
+    @Query(
+            "delete from PlanParticipant p " +
             "      where p.reviewId = :reviewId "
     )
     void deleteByReviewId(Long reviewId);

--- a/src/main/java/com/mople/notification/reader/NotificationUserReader.java
+++ b/src/main/java/com/mople/notification/reader/NotificationUserReader.java
@@ -5,6 +5,7 @@ import com.mople.entity.meet.comment.QCommentMention;
 import com.mople.entity.meet.comment.QPlanComment;
 import com.mople.entity.meet.plan.QPlanParticipant;
 import com.mople.entity.user.QUser;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -46,13 +47,25 @@ public class NotificationUserReader {
                 .fetch();
     }
 
-    public List<Long> findReviewUsersNoTriggers(Long triggeredBy, Long reviewId) {
+    public List<Long> findReviewUsersNoTriggers(Long triggeredBy, Long reviewId, Long meetId) {
         QPlanParticipant participant = QPlanParticipant.planParticipant;
+        QMeetMember meetMember = QMeetMember.meetMember;
 
         return queryFactory
                 .select(participant.userId)
                 .from(participant)
-                .where(participant.reviewId.eq(reviewId), participant.userId.ne(triggeredBy))
+                .where(
+                        participant.reviewId.eq(reviewId),
+                        participant.userId.ne(triggeredBy),
+                        JPAExpressions
+                                .selectOne()
+                                .from(meetMember)
+                                .where(
+                                        meetMember.meetId.eq(meetId),
+                                        meetMember.userId.eq(participant.userId)
+                                )
+                                .exists()
+                )
                 .fetch();
     }
 
@@ -66,35 +79,56 @@ public class NotificationUserReader {
                 .fetch();
     }
 
-    public Long findCommentRepliedUserNoWriter(Long senderId, Long parentCommentId) {
+    public Long findCommentRepliedUserNoWriter(Long senderId, Long parentCommentId, Long meetId) {
         QPlanComment planComment = QPlanComment.planComment;
+        QMeetMember meetMember = QMeetMember.meetMember;
 
         return queryFactory
                 .select(planComment.writerId)
                 .from(planComment)
-                .where(planComment.id.eq(parentCommentId), planComment.writerId.ne(senderId))
+                .where(
+                        planComment.id.eq(parentCommentId),
+                        planComment.writerId.ne(senderId),
+                        JPAExpressions
+                                .selectOne()
+                                .from(meetMember)
+                                .where(
+                                        meetMember.meetId.eq(meetId),
+                                        meetMember.userId.eq(planComment.writerId)
+                                )
+                                .exists()
+                )
                 .fetchOne();
     }
 
-    private List<Long> findCommentMentionedUsersNoWriter(Long senderId, Long commentId) {
+    private List<Long> findCommentMentionedUsersNoWriter(Long senderId, Long commentId, Long meetId) {
         QCommentMention mention = QCommentMention.commentMention;
+        QMeetMember meetMember = QMeetMember.meetMember;
 
         return queryFactory
-                .select(mention.userId)
+                .selectDistinct(mention.userId)
                 .from(mention)
                 .where(
                         mention.commentId.eq(commentId),
-                        mention.userId.ne(senderId)
+                        mention.userId.ne(senderId),
+                        JPAExpressions
+                                .selectOne()
+                                .from(meetMember)
+                                .where(
+                                        meetMember.meetId.eq(meetId),
+                                        meetMember.userId.eq(mention.userId)
+                                )
+                                .exists()
                 )
                 .fetch();
     }
 
-    public List<Long> findCreatedMentionedUsers(Long senderId, Long commentId) {
-        return findCommentMentionedUsersNoWriter(senderId, commentId);
+    public List<Long> findCreatedMentionedUsers(Long senderId, Long commentId, Long meetId) {
+        return findCommentMentionedUsersNoWriter(senderId, commentId, meetId);
     }
 
-    public List<Long> findUpdatedMentionedUsers(List<Long> originMentions, Long senderId, Long commentId) {
-        List<Long> targetIds = findCommentMentionedUsersNoWriter(senderId, commentId);
+    public List<Long> findUpdatedMentionedUsers(List<Long> originMentions, Long senderId, Long commentId, Long meetId) {
+        List<Long> targetIds = findCommentMentionedUsersNoWriter(senderId, commentId, meetId);
 
         return targetIds.stream()
                 .filter(targetId -> !originMentions.contains(targetId))


### PR DESCRIPTION
# meet left 시 일정 참가자만 삭제, 일정 페이징에 creatorId 추가
---
## meet left 시 일정 참가자만 삭제


이벤트 처리로 바꾸면서 기존에는 모임 탈퇴(Meet 삭제 X) 했을 때
`meetMember` 삭제 처리,
 자신이 작성한 `plan`과 `review`만 삭제 처리,
참여한 `plan`과 `review`의 `planParticipant` 와 `planComment` 를 모두 냅뒀습니다.

이번 회의에서 모임 탈퇴 시 요구사항이 변경되었습니다:
- `plan`과 `review`의 `planComment`은 과거 기록이니 냅두기
- `review`의 `planParticipant`도 과거 기록이니 냅두기
- `plan`의 `planParticipant` 만 삭제

따라서 `planComment` 관련 알림에서 알림 대상이 `meetMember`인지 확인하는 로직이 추가되었습니다.
(이 부분에서 `postId`로 `plan`/`review` 분기 로직이 복잡하여 `PostContextFinder` 를 추가하여 재사용했습니다. 
근데 이 클래스를 패키지 어디에 위치해야할지 고민하다가 모르겠어서 그 근처에 놨습니다,,,! 혹시 제안 주실 부분 있으면 바로 수정하겠습니다!!)

그리고 `review` 리마인드 알림에서도 `planParticipant`를 삭제하지 않기 떄문에 `meetMember`인지 확인하는 로직이 추가되었습니다.

---
## 일정 페이징에 `creatorId` 추가

`plan`에서 작성자이면 날씨 UI 위치에 `장소가 정해지지 않았어요` 같은 문구가 출력되어야 하기 때문에
`UserPageResponse` 에 `creatorId` 필드를 추가했습니다!!

---
우선 테스트로 전부 확인해봤습니다!!
더 나은 방안이나 수정할 부분 있으시다면 편하게 남겨주세요 대영님!!
항상 감사합니다 🫡

