### PR TITLE
refactor: plan/review 페이징 쿼리 n+1 제거 및 인덱스 사용

### DIFF
--- a/src/main/java/com/mople/dto/response/meet/plan/PlanListResponse.java
+++ b/src/main/java/com/mople/dto/response/meet/plan/PlanListResponse.java
@@ -1,7 +1,12 @@
 package com.mople.dto.response.meet.plan;
 
+import com.mople.entity.meet.Meet;
+import com.mople.entity.meet.plan.MeetPlan;
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
+@Builder
 public record PlanListResponse(
         Long planId,
         Long version,
@@ -20,4 +25,29 @@ public record PlanListResponse(
         Double pop,
         boolean participant
 ) {
+    public PlanListResponse(
+            Meet meet,
+            MeetPlan plan,
+            Integer planMemberCount,
+            boolean isParticipant
+    ) {
+        this(
+                plan.getId(),
+                plan.getVersion(),
+                meet.getId(),
+                meet.getName(),
+                meet.getMeetImage(),
+                plan.getName(),
+                planMemberCount,
+                plan.getPlanTime(),
+                plan.getAddress(),
+                plan.getTitle(),
+                plan.getCreatorId(),
+                plan.getWeatherIcon(),
+                plan.getWeatherAddress(),
+                plan.getTemperature(),
+                plan.getPop(),
+                isParticipant
+        );
+    }
 }

--- a/src/main/java/com/mople/image/controller/ImageController.java
+++ b/src/main/java/com/mople/image/controller/ImageController.java
@@ -4,7 +4,7 @@ import com.mople.core.annotation.auth.SignUser;
 import com.mople.dto.request.meet.review.ReviewImageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
 import com.mople.image.service.ImageService;
-import com.mople.meet.service.ReviewService;
+import com.mople.meet.service.review.ReviewService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/com/mople/meet/controller/ReviewController.java
+++ b/src/main/java/com/mople/meet/controller/ReviewController.java
@@ -9,7 +9,7 @@ import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
 import com.mople.dto.response.meet.review.ReviewImageListResponse;
 import com.mople.dto.response.pagination.FlatCursorPageResponse;
-import com.mople.meet.service.ReviewService;
+import com.mople.meet.service.review.ReviewService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/com/mople/meet/repository/impl/plan/ParticipantRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/plan/ParticipantRepositorySupport.java
@@ -9,7 +9,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -74,5 +75,54 @@ public class ParticipantRepositorySupport {
                 )
                 .limit(size + 1)
                 .fetch();
+    }
+
+    public Map<Long, Integer> reviewParticipantCountMap(List<Long> reviewIds) {
+        QPlanParticipant participant = QPlanParticipant.planParticipant;
+
+         return queryFactory
+                .select(participant.reviewId, participant.count())
+                .from(participant)
+                .where(participant.reviewId.in(reviewIds))
+                .groupBy(participant.reviewId)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(participant.reviewId),
+                        tuple -> Objects.requireNonNull(tuple.get(participant.count())).intValue()
+                        )
+                );
+    }
+
+    public Map<Long, Integer> planParticipantCountMap(List<Long> planIds) {
+        QPlanParticipant participant = QPlanParticipant.planParticipant;
+
+         return queryFactory
+                .select(participant.planId, participant.count())
+                .from(participant)
+                .where(participant.planId.in(planIds))
+                .groupBy(participant.planId)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(participant.planId),
+                        tuple -> Objects.requireNonNull(tuple.get(participant.count())).intValue()
+                        )
+                );
+    }
+
+    public Set<Long> findJoinedPlanIds(Long userId, List<Long> planIds) {
+        QPlanParticipant participant = QPlanParticipant.planParticipant;
+
+        return new HashSet<>(
+                queryFactory
+                        .select(participant.planId)
+                        .from(participant)
+                        .where(
+                                participant.planId.in(planIds),
+                                participant.userId.eq(userId)
+                        )
+                        .fetch()
+        );
     }
 }

--- a/src/main/java/com/mople/meet/repository/impl/plan/PlanRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/plan/PlanRepositorySupport.java
@@ -4,9 +4,9 @@ import com.mople.dto.response.meet.PlanPageResponse;
 import com.mople.dto.response.meet.ReviewPageResponse;
 import com.mople.dto.response.meet.UserAllDateResponse;
 import com.mople.dto.response.meet.UserPageResponse;
-import com.mople.dto.response.meet.plan.PlanListResponse;
 import com.mople.dto.response.meet.plan.PlanViewResponse;
 import com.mople.entity.meet.*;
+import com.mople.entity.meet.plan.MeetPlan;
 import com.mople.entity.meet.plan.QMeetPlan;
 import com.mople.entity.meet.plan.QPlanParticipant;
 import com.mople.entity.meet.review.QPlanReview;
@@ -88,15 +88,11 @@ public class PlanRepositorySupport {
                 .fetch();
     }
 
-    public List<PlanListResponse> findPlanPage(Long userId, Long meetId, Long cursorId, int size) {
-        QMeet meet = QMeet.meet;
+    public List<MeetPlan> findPlanPage(Long meetId, Long cursorId, int size) {
         QMeetPlan plan = QMeetPlan.meetPlan;
-        QPlanParticipant participant = QPlanParticipant.planParticipant;
-        QPlanParticipant ppAll = new QPlanParticipant("ppAll");
 
         BooleanBuilder whereCondition = new BooleanBuilder()
                 .and(plan.status.eq(Status.ACTIVE))
-                .and(meet.status.eq(Status.ACTIVE))
                 .and(plan.meetId.eq(meetId))
                 .and(plan.planTime.after(
                         Expressions.dateTimeOperation(
@@ -118,42 +114,8 @@ public class PlanRepositorySupport {
             );
         }
 
-        BooleanExpression joinedByUser = JPAExpressions
-                .selectOne()
-                .from(participant)
-                .where(
-                        participant.planId.eq(plan.id)
-                                .and(participant.userId.eq(userId))
-                )
-                .exists();
-
         return queryFactory
-                .select(
-                        Projections.constructor(
-                                PlanListResponse.class,
-                                plan.id,
-                                plan.version,
-                                meet.id,
-                                meet.name,
-                                meet.meetImage,
-                                plan.name,
-                                JPAExpressions
-                                        .select(ppAll.count().intValue())
-                                        .from(ppAll)
-                                        .where(ppAll.planId.eq(plan.id)),
-                                plan.planTime,
-                                plan.address,
-                                plan.title,
-                                plan.creatorId,
-                                plan.weatherIcon,
-                                plan.weatherAddress,
-                                plan.temperature,
-                                plan.pop,
-                                joinedByUser
-                        )
-                )
-                .from(plan)
-                .join(meet).on(meet.id.eq(plan.meetId))
+                .selectFrom(plan)
                 .where(whereCondition)
                 .orderBy(plan.planTime.asc(), plan.id.asc())
                 .limit(size + 1)

--- a/src/main/java/com/mople/meet/repository/impl/review/ReviewImageRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/review/ReviewImageRepositorySupport.java
@@ -1,0 +1,29 @@
+package com.mople.meet.repository.impl.review;
+
+import com.mople.entity.meet.review.QReviewImage;
+import com.mople.entity.meet.review.ReviewImage;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewImageRepositorySupport {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Map<Long, List<ReviewImage>> reviewImageMap(List<Long> reviewIds) {
+        QReviewImage image = QReviewImage.reviewImage1;
+
+         return queryFactory
+                .selectFrom(image)
+                .where(image.reviewId.in(reviewIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(ReviewImage::getReviewId));
+    }
+}

--- a/src/main/java/com/mople/meet/service/plan/PlanService.java
+++ b/src/main/java/com/mople/meet/service/plan/PlanService.java
@@ -53,6 +53,7 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.mople.dto.client.PlanClientResponse.*;
 import static com.mople.dto.client.UserRoleClientResponse.ofParticipants;
@@ -294,22 +295,40 @@ public class PlanService {
     @Transactional(readOnly = true)
     public FlatCursorPageResponse<PlanClientResponse> getPlanList(Long userId, Long meetId, CursorPageRequest request) {
         reader.findUser(userId);
-        reader.findMeet(meetId);
+        Meet meet = reader.findMeet(meetId);
 
         if (!memberRepository.existsByMeetIdAndUserId(meetId, userId)) {
             throw new AuthException(NOT_MEMBER);
         }
 
         int size = request.getSafeSize();
-        List<PlanListResponse> plans = getPlans(userId, meetId, request.cursor(), size);
+        List<MeetPlan> plans = getPlans(meetId, request.cursor(), size);
+
+        List<Long> planIds = plans.stream()
+                .map(MeetPlan::getId)
+                .toList();
+
+        Map<Long, Integer> participantCountMap = participantRepositorySupport.planParticipantCountMap(planIds);
+        Set<Long> joinedPlanIds = participantRepositorySupport.findJoinedPlanIds(userId, planIds);
+
+        List<PlanListResponse> responses = plans.stream()
+                .map((p) ->
+                        new PlanListResponse(
+                                meet,
+                                p,
+                                participantCountMap.getOrDefault(p.getId(), 0),
+                                joinedPlanIds.contains(p.getId())
+                        )
+                )
+                .toList();
 
         return FlatCursorPageResponse.of(
                 meetPlanRepository.countByMeetIdAndStatus(meetId, Status.ACTIVE),
-                buildPlanCursorPage(size, plans)
+                buildPlanCursorPage(size, responses)
         );
     }
 
-    private List<PlanListResponse> getPlans(Long userId, Long meetId, String encodedCursor, int size) {
+    private List<MeetPlan> getPlans(Long meetId, String encodedCursor, int size) {
 
         Long cursorId = null;
 
@@ -320,7 +339,7 @@ public class PlanService {
             validatePlanCursor(cursorId);
         }
 
-        return planRepositorySupport.findPlanPage(userId, meetId, cursorId, size);
+        return planRepositorySupport.findPlanPage(meetId, cursorId, size);
     }
 
     private void validatePlanCursor(Long cursorId) {

--- a/src/main/java/com/mople/meet/service/review/ReviewService.java
+++ b/src/main/java/com/mople/meet/service/review/ReviewService.java
@@ -1,4 +1,4 @@
-package com.mople.meet.service;
+package com.mople.meet.service.review;
 
 import com.mople.core.exception.custom.*;
 import com.mople.dto.client.ReviewClientResponse;
@@ -26,6 +26,7 @@ import com.mople.meet.reader.EntityReader;
 import com.mople.meet.repository.MeetMemberRepository;
 import com.mople.meet.repository.impl.comment.CommentRepositorySupport;
 import com.mople.meet.repository.impl.plan.ParticipantRepositorySupport;
+import com.mople.meet.repository.impl.review.ReviewImageRepositorySupport;
 import com.mople.meet.repository.impl.review.ReviewRepositorySupport;
 import com.mople.meet.repository.plan.PlanParticipantRepository;
 import com.mople.meet.repository.review.PlanReviewRepository;
@@ -68,6 +69,7 @@ public class ReviewService {
 
     private final PlanReviewRepository planReviewRepository;
     private final PlanParticipantRepository participantRepository;
+    private final ReviewImageRepositorySupport reviewImageRepositorySupport;
     private final ReviewImageRepository reviewImageRepository;
     private final ReviewReportRepository reviewReportRepository;
     private final CommentRepositorySupport commentRepositorySupport;
@@ -90,13 +92,22 @@ public class ReviewService {
 
         int size = request.getSafeSize();
         List<PlanReview> reviews = getReviews(meetId, request.cursor(), size);
-        List<PlanReviewInfoResponse> reviewInfoResponses = reviews.stream()
-                .map((r) -> {
-                    Integer participantCount = participantRepository.countByReviewId(r.getId());
-                    List<ReviewImage> images = reviewImageRepository.findByReviewId(r.getId());
 
-                    return new PlanReviewInfoResponse(r, participantCount, images);
-                })
+        List<Long> reviewIds = reviews.stream()
+                .map(PlanReview::getId)
+                .toList();
+
+        Map<Long, Integer> participantCountMap = participantRepositorySupport.reviewParticipantCountMap(reviewIds);
+        Map<Long, List<ReviewImage>> imageMap = reviewImageRepositorySupport.reviewImageMap(reviewIds);
+
+        List<PlanReviewInfoResponse> reviewInfoResponses = reviews.stream()
+                .map((r) ->
+                        new PlanReviewInfoResponse(
+                                r,
+                                participantCountMap.getOrDefault(r.getId(), 0),
+                                imageMap.getOrDefault(r.getId(), List.of())
+                        )
+                )
                 .toList();
 
         return FlatCursorPageResponse.of(


### PR DESCRIPTION
# plan 페이징, review 페이징 쿼리 수정
---
## plan 페이징

`projection` 사용 해서 DTO를 한번에 생성하지만, 여러 조인과 서브 쿼리가 섞여 있어
 인덱스를 타지 않고 `Seq Scan` 으로 일일이 비교하는 것을 확인했습니다...!
따라서 페이징 쿼리에서는 `projection`을 없애고, 
합쳐주는 방식으로 변경하였습니다!

---
## review 페이징

`reviews`를 가져온 뒤, `map( )`안에서 `reviewImage`, `participantCount` 쿼리를 실행시켜
 `n + 1` 문제가 발생하는 것을 확인했습니다.
이 부분도 `Map` 형태로 한번에 가져오는 방식으로 변경하였습니다!!

모든 페이징 인덱스 다 적용되는 것을 확인했습니다!!
간편하게 할 수 있게 `vpn` 구축해주셔서 정말루 감사합니다 대영님 !!! 🫡