### PR TITLE
Feat/meeting notice

### DIFF
--- a/src/main/java/com/mople/dto/client/NoticeClientResponse.java
+++ b/src/main/java/com/mople/dto/client/NoticeClientResponse.java
@@ -1,7 +1,7 @@
 package com.mople.dto.client;
 
 import com.mople.entity.meet.notice.MeetNotice;
-import com.mople.global.enums.NoticeType;
+import com.mople.global.enums.notice.NoticeType;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/mople/dto/client/NoticeClientResponse.java
+++ b/src/main/java/com/mople/dto/client/NoticeClientResponse.java
@@ -1,0 +1,32 @@
+package com.mople.dto.client;
+
+import com.mople.entity.meet.notice.MeetNotice;
+import com.mople.global.enums.NoticeType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class NoticeClientResponse {
+    private final Long noticeId;
+    private final Long version;
+    private final Long meetId;
+    private final NoticeType type;
+    private final String content;
+
+    public static List<NoticeClientResponse> ofNotices(List<MeetNotice> notices) {
+        return notices.stream().map(NoticeClientResponse::ofNotice).toList();
+    }
+
+    public static NoticeClientResponse ofNotice(MeetNotice notice) {
+        return NoticeClientResponse.builder()
+                .noticeId(notice.getId())
+                .version(notice.getVersion())
+                .meetId(notice.getMeetId())
+                .type(notice.getType())
+                .content(notice.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/mople/dto/client/PlanClientResponse.java
+++ b/src/main/java/com/mople/dto/client/PlanClientResponse.java
@@ -35,34 +35,10 @@ public class PlanClientResponse {
     private final Integer commentCount;
 
     public static List<PlanClientResponse> ofViews(List<PlanViewResponse> viewResponses) {
-        return viewResponses.stream().map(response -> ofView(response, 0)).toList();
+        return viewResponses.stream().map(response -> ofView(response, true, 0)).toList();
     }
 
-    public static PlanClientResponse ofView(PlanViewResponse viewResponse, Integer commentCount) {
-        return PlanClientResponse.builder()
-                .planId(viewResponse.planId())
-                .version(viewResponse.version())
-                .meetId(viewResponse.meetId())
-                .meetName(viewResponse.meetName())
-                .meetImg(viewResponse.meetImage())
-                .planName(viewResponse.planName())
-                .planMemberCount(viewResponse.planMemberCount())
-                .planTime(viewResponse.planTime())
-                .planAddress(viewResponse.planAddress())
-                .title(viewResponse.title())
-                .description(viewResponse.description())
-                .creatorId(viewResponse.creatorId())
-                .lat(viewResponse.lat())
-                .lot(viewResponse.lot())
-                .weatherIcon(viewResponse.weatherIcon())
-                .weatherAddress(viewResponse.weatherAddress())
-                .temperature(viewResponse.temperature())
-                .pop(viewResponse.pop())
-                .commentCount(commentCount)
-                .build();
-    }
-
-    public static PlanClientResponse ofViewAndParticipant(PlanViewResponse viewResponse, boolean participant, Integer commentCount) {
+    public static PlanClientResponse ofView(PlanViewResponse viewResponse, boolean participant, Integer commentCount) {
         return PlanClientResponse.builder()
                 .planId(viewResponse.planId())
                 .version(viewResponse.version())
@@ -83,31 +59,6 @@ public class PlanClientResponse {
                 .temperature(viewResponse.temperature())
                 .pop(viewResponse.pop())
                 .participant(participant)
-                .commentCount(commentCount)
-                .build();
-    }
-
-    public static PlanClientResponse ofUpdate(PlanViewResponse viewResponse, Integer commentCount) {
-        return PlanClientResponse.builder()
-                .planId(viewResponse.planId())
-                .version(viewResponse.version())
-                .meetId(viewResponse.meetId())
-                .meetName(viewResponse.meetName())
-                .meetImg(viewResponse.meetImage())
-                .planName(viewResponse.planName())
-                .planMemberCount(viewResponse.planMemberCount())
-                .planTime(viewResponse.planTime())
-                .planAddress(viewResponse.planAddress())
-                .title(viewResponse.title())
-                .description(viewResponse.description())
-                .creatorId(viewResponse.creatorId())
-                .lat(viewResponse.lat())
-                .lot(viewResponse.lot())
-                .weatherIcon(viewResponse.weatherIcon())
-                .weatherAddress(viewResponse.weatherAddress())
-                .temperature(viewResponse.temperature())
-                .pop(viewResponse.pop())
-                .participant(true)
                 .commentCount(commentCount)
                 .build();
     }

--- a/src/main/java/com/mople/dto/request/meet/notice/NoticeCreateRequest.java
+++ b/src/main/java/com/mople/dto/request/meet/notice/NoticeCreateRequest.java
@@ -1,0 +1,7 @@
+package com.mople.dto.request.meet.notice;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NoticeCreateRequest(
+        @NotBlank String content
+) {}

--- a/src/main/java/com/mople/dto/request/meet/notice/NoticeCreateRequest.java
+++ b/src/main/java/com/mople/dto/request/meet/notice/NoticeCreateRequest.java
@@ -3,5 +3,6 @@ package com.mople.dto.request.meet.notice;
 import jakarta.validation.constraints.NotBlank;
 
 public record NoticeCreateRequest(
+        Long meetId,
         @NotBlank String content
 ) {}

--- a/src/main/java/com/mople/dto/request/meet/notice/NoticeUpdateRequest.java
+++ b/src/main/java/com/mople/dto/request/meet/notice/NoticeUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.mople.dto.request.meet.notice;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NoticeUpdateRequest(
+        @NotBlank String content
+) {}

--- a/src/main/java/com/mople/dto/request/meet/notice/NoticeUpdateRequest.java
+++ b/src/main/java/com/mople/dto/request/meet/notice/NoticeUpdateRequest.java
@@ -3,5 +3,6 @@ package com.mople.dto.request.meet.notice;
 import jakarta.validation.constraints.NotBlank;
 
 public record NoticeUpdateRequest(
+        Long meetId,
         @NotBlank String content
 ) {}

--- a/src/main/java/com/mople/entity/meet/notice/MeetNotice.java
+++ b/src/main/java/com/mople/entity/meet/notice/MeetNotice.java
@@ -1,0 +1,71 @@
+package com.mople.entity.meet.notice;
+
+import com.mople.entity.common.BaseTimeEntity;
+import com.mople.global.enums.NoticeType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "meet_notice")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetNotice extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(name = "notice_id")
+    private Long id;
+
+    @Version
+    private Long version;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private NoticeType type;
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "creator_id")
+    private Long creatorId;
+
+    @Column(name = "meet_id", nullable = false)
+    private Long meetId;
+
+    @Builder
+    public MeetNotice(NoticeType type, String content, Long creatorId, Long meetId) {
+        this.type = type;
+        this.content = content;
+        this.creatorId = creatorId;
+        this.meetId = meetId;
+    }
+
+    public static MeetNotice ofCustom(String content, Long creatorId, Long meetId) {
+        return MeetNotice.builder()
+                .type(NoticeType.HOST_CUSTOM)
+                .content(content)
+                .creatorId(creatorId)
+                .meetId(meetId)
+                .build();
+    }
+
+    public static MeetNotice ofSystem(NoticeType type, String content, Long meetId) {
+        return MeetNotice.builder()
+                .type(type)
+                .content(content)
+                .creatorId(null)
+                .meetId(meetId)
+                .build();
+    }
+
+    public void updateNotice(String content) {
+        if (content == null || content.isBlank()) {
+            return;
+        }
+
+        this.content = content;
+    }
+}

--- a/src/main/java/com/mople/entity/meet/notice/MeetNotice.java
+++ b/src/main/java/com/mople/entity/meet/notice/MeetNotice.java
@@ -1,7 +1,7 @@
 package com.mople.entity.meet.notice;
 
 import com.mople.entity.common.BaseTimeEntity;
-import com.mople.global.enums.NoticeType;
+import com.mople.global.enums.notice.NoticeType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -45,16 +45,16 @@ public class MeetNotice extends BaseTimeEntity {
 
     public static MeetNotice ofCustom(String content, Long creatorId, Long meetId) {
         return MeetNotice.builder()
-                .type(NoticeType.HOST_CUSTOM)
+                .type(NoticeType.CUSTOM)
                 .content(content)
                 .creatorId(creatorId)
                 .meetId(meetId)
                 .build();
     }
 
-    public static MeetNotice ofSystem(NoticeType type, String content, Long meetId) {
+    public static MeetNotice ofSystem(String content, Long meetId) {
         return MeetNotice.builder()
-                .type(type)
+                .type(NoticeType.SYSTEM)
                 .content(content)
                 .creatorId(null)
                 .meetId(meetId)

--- a/src/main/java/com/mople/global/enums/ExceptionReturnCode.java
+++ b/src/main/java/com/mople/global/enums/ExceptionReturnCode.java
@@ -31,6 +31,7 @@ public enum ExceptionReturnCode {
 
     // Meet
     NOT_CREATOR("401", "접근 권한이 없습니다."),
+    NOT_HOST("401", "접근 권한이 없습니다."),
     UNAUTHORIZED_DELETE("401", "삭제 권한이 없습니다."),
     NOT_FOUND_MEET("404", "모임을 찾을 수 없습니다."),
     INVALID_INVITE_CODE("400", "유효하지 않은 초대 코드입니다."),

--- a/src/main/java/com/mople/global/enums/ExceptionReturnCode.java
+++ b/src/main/java/com/mople/global/enums/ExceptionReturnCode.java
@@ -67,6 +67,9 @@ public enum ExceptionReturnCode {
     NOT_FOUND_COMMENT_STATS("404", "댓글 정보를 찾을 수 없습니다."),
     INVALID_COMMENT("400", "유효하지 않은 댓글입니다."),
 
+    // notice
+    NOT_FOUND_NOTICE("404", "공지를 찾을 수 없습니다."),
+
     // cursor
     INVALID_CURSOR("400", "잘못된 커서입니다."),
     FAIL_DECODING_CURSOR("400", "커서를 디코딩할 수 없습니다."),

--- a/src/main/java/com/mople/global/enums/NoticeType.java
+++ b/src/main/java/com/mople/global/enums/NoticeType.java
@@ -1,7 +1,0 @@
-package com.mople.global.enums;
-
-public enum NoticeType {
-    HOST_CUSTOM,
-    SYSTEM_HOST_CHANGED,
-    SYSTEM_MEMBER_JOINED
-}

--- a/src/main/java/com/mople/global/enums/NoticeType.java
+++ b/src/main/java/com/mople/global/enums/NoticeType.java
@@ -1,0 +1,7 @@
+package com.mople.global.enums;
+
+public enum NoticeType {
+    HOST_CUSTOM,
+    SYSTEM_HOST_CHANGED,
+    SYSTEM_MEMBER_JOINED
+}

--- a/src/main/java/com/mople/global/enums/notice/NoticeType.java
+++ b/src/main/java/com/mople/global/enums/notice/NoticeType.java
@@ -1,0 +1,6 @@
+package com.mople.global.enums.notice;
+
+public enum NoticeType {
+    CUSTOM,
+    SYSTEM
+}

--- a/src/main/java/com/mople/global/enums/notice/SystemNotice.java
+++ b/src/main/java/com/mople/global/enums/notice/SystemNotice.java
@@ -1,0 +1,16 @@
+package com.mople.global.enums.notice;
+
+public enum SystemNotice {
+    HOST_CHANGED("모임장이 %s님에서 %s님으로 변경되었습니다."),
+    MEET_JOINED("%s님이 모임에 참여하였습니다.");
+
+    private final String content;
+
+    SystemNotice(String content) {
+        this.content = content;
+    }
+
+    public String format(Object... args) {
+        return String.format(content, args);
+    }
+}

--- a/src/main/java/com/mople/global/event/handler/domain/impl/meet/join/MeetJoinedNoticeCreator.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/meet/join/MeetJoinedNoticeCreator.java
@@ -1,0 +1,40 @@
+package com.mople.global.event.handler.domain.impl.meet.join;
+
+import com.mople.core.exception.custom.NonRetryableOutboxException;
+import com.mople.dto.event.data.domain.meet.MeetJoinedEvent;
+import com.mople.entity.user.User;
+import com.mople.global.enums.Status;
+import com.mople.global.enums.notice.SystemNotice;
+import com.mople.global.event.handler.domain.DomainEventHandler;
+import com.mople.meet.service.notice.NoticeSystemService;
+import com.mople.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.mople.global.enums.ExceptionReturnCode.NOT_FOUND_MEMBER;
+
+@Component
+@RequiredArgsConstructor
+public class MeetJoinedNoticeCreator implements DomainEventHandler<MeetJoinedEvent> {
+
+    private final NoticeSystemService noticeSystemService;
+    private final UserRepository userRepository;
+
+    @Override
+    public Class<MeetJoinedEvent> getHandledType() {
+        return MeetJoinedEvent.class;
+    }
+
+    @Override
+    public void handle(MeetJoinedEvent event) {
+
+        User newMember = userRepository.findByIdAndStatus(event.newMemberId(), Status.ACTIVE)
+                .orElseThrow(() -> new NonRetryableOutboxException(NOT_FOUND_MEMBER));
+
+        noticeSystemService.publishSystemNotice(
+                event.meetId(),
+                SystemNotice.MEET_JOINED,
+                newMember.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/mople/global/event/handler/domain/impl/meet/update/HostChangedNoticeCreator.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/meet/update/HostChangedNoticeCreator.java
@@ -1,0 +1,43 @@
+package com.mople.global.event.handler.domain.impl.meet.update;
+
+import com.mople.core.exception.custom.NonRetryableOutboxException;
+import com.mople.dto.event.data.domain.meet.HostChangedEvent;
+import com.mople.entity.user.User;
+import com.mople.global.enums.Status;
+import com.mople.global.enums.notice.SystemNotice;
+import com.mople.global.event.handler.domain.DomainEventHandler;
+import com.mople.meet.service.notice.NoticeSystemService;
+import com.mople.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.mople.global.enums.ExceptionReturnCode.NOT_FOUND_MEMBER;
+
+@Component
+@RequiredArgsConstructor
+public class HostChangedNoticeCreator implements DomainEventHandler<HostChangedEvent> {
+
+    private final NoticeSystemService noticeSystemService;
+    private final UserRepository userRepository;
+
+    @Override
+    public Class<HostChangedEvent> getHandledType() {
+        return HostChangedEvent.class;
+    }
+
+    @Override
+    public void handle(HostChangedEvent event) {
+        User oldHost = userRepository.findByIdAndStatus(event.oldHostId(), Status.ACTIVE)
+                .orElseThrow(() -> new NonRetryableOutboxException(NOT_FOUND_MEMBER));
+
+        User newHost = userRepository.findByIdAndStatus(event.newHostId(), Status.ACTIVE)
+                .orElseThrow(() -> new NonRetryableOutboxException(NOT_FOUND_MEMBER));
+
+        noticeSystemService.publishSystemNotice(
+                event.meetId(),
+                SystemNotice.HOST_CHANGED,
+                oldHost.getNickname(),
+                newHost.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/mople/meet/controller/NoticeController.java
+++ b/src/main/java/com/mople/meet/controller/NoticeController.java
@@ -4,13 +4,16 @@ import com.mople.core.annotation.auth.SignUser;
 import com.mople.dto.client.NoticeClientResponse;
 import com.mople.dto.request.meet.notice.NoticeCreateRequest;
 import com.mople.dto.request.meet.notice.NoticeUpdateRequest;
+import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
+import com.mople.dto.response.pagination.CursorPageResponse;
 import com.mople.meet.service.notice.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,6 +24,19 @@ import org.springframework.web.bind.annotation.*;
 public class NoticeController {
 
     private final NoticeService noticeService;
+
+    @Operation(
+            summary = "공지 조회 API",
+            description = "모임의 공지 목록을 조회합니다."
+    )
+    @GetMapping("/list/{meetId}")
+    public ResponseEntity<CursorPageResponse<NoticeClientResponse>> getMeetNoticeList(
+            @Parameter(hidden = true) @SignUser AuthUserRequest user,
+            @PathVariable Long meetId,
+            @ParameterObject @Valid CursorPageRequest request
+    ) {
+        return ResponseEntity.ok(noticeService.getNoticeList(user.id(), meetId, request));
+    }
 
     @Operation(
             summary = "공지 생성 API",

--- a/src/main/java/com/mople/meet/controller/NoticeController.java
+++ b/src/main/java/com/mople/meet/controller/NoticeController.java
@@ -15,7 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/meet/{meetId}/notices")
+@RequestMapping("/notice")
 @RequiredArgsConstructor
 @Tag(name = "NOTICE", description = "공지 API")
 public class NoticeController {
@@ -26,13 +26,12 @@ public class NoticeController {
             summary = "공지 생성 API",
             description = "모임장이 공지를 생성하고, 생성된 공지 정보를 반환합니다."
     )
-    @PostMapping
+    @PostMapping("/create")
     public ResponseEntity<NoticeClientResponse> createMeetNotice(
             @Parameter(hidden = true) @SignUser AuthUserRequest user,
-            @PathVariable Long meetId,
             @RequestBody @Valid NoticeCreateRequest request
     ) {
-        var body = noticeService.createNotice(user.id(), meetId, request);
+        var body = noticeService.createNotice(user.id(), request);
 
         return ResponseEntity.ok()
                 .eTag("\"" + body.getVersion() + "\"")
@@ -43,14 +42,13 @@ public class NoticeController {
             summary = "공지 수정 API",
             description = "모임장이 공지 내용을 수정하고, 수정된 공지 정보를 반환합니다."
     )
-    @PatchMapping("/{noticeId}")
+    @PatchMapping("/update/{noticeId}")
     public ResponseEntity<NoticeClientResponse> updateMeetNotice(
             @Parameter(hidden = true) @SignUser AuthUserRequest user,
-            @PathVariable Long meetId,
             @PathVariable Long noticeId,
             @RequestBody @Valid NoticeUpdateRequest request
     ) {
-        var body = noticeService.updateNotice(user.id(), meetId, noticeId, request);
+        var body = noticeService.updateNotice(user.id(), noticeId, request);
 
         return ResponseEntity.ok()
                 .eTag("\"" + body.getVersion() + "\"")

--- a/src/main/java/com/mople/meet/controller/NoticeController.java
+++ b/src/main/java/com/mople/meet/controller/NoticeController.java
@@ -54,4 +54,17 @@ public class NoticeController {
                 .eTag("\"" + body.getVersion() + "\"")
                 .body(body);
     }
+
+    @Operation(
+            summary = "공지 삭제 API",
+            description = "모임장이 공지를 삭제합니다."
+    )
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<Void> deleteMeetNotice(
+            @Parameter(hidden = true) @SignUser AuthUserRequest user,
+            @PathVariable Long noticeId
+    ) {
+        noticeService.removeNotice(user.id(), noticeId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/mople/meet/controller/NoticeController.java
+++ b/src/main/java/com/mople/meet/controller/NoticeController.java
@@ -1,0 +1,16 @@
+package com.mople.meet.controller;
+
+import com.mople.meet.service.notice.NoticeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/meet/{meetId}/notices")
+@RequiredArgsConstructor
+@Tag(name = "NOTICE", description = "공지 API")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+}

--- a/src/main/java/com/mople/meet/controller/NoticeController.java
+++ b/src/main/java/com/mople/meet/controller/NoticeController.java
@@ -3,6 +3,7 @@ package com.mople.meet.controller;
 import com.mople.core.annotation.auth.SignUser;
 import com.mople.dto.client.NoticeClientResponse;
 import com.mople.dto.request.meet.notice.NoticeCreateRequest;
+import com.mople.dto.request.meet.notice.NoticeUpdateRequest;
 import com.mople.dto.request.user.AuthUserRequest;
 import com.mople.meet.service.notice.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,6 +33,24 @@ public class NoticeController {
             @RequestBody @Valid NoticeCreateRequest request
     ) {
         var body = noticeService.createNotice(user.id(), meetId, request);
+
+        return ResponseEntity.ok()
+                .eTag("\"" + body.getVersion() + "\"")
+                .body(body);
+    }
+
+    @Operation(
+            summary = "공지 수정 API",
+            description = "모임장이 공지 내용을 수정하고, 수정된 공지 정보를 반환합니다."
+    )
+    @PatchMapping("/{noticeId}")
+    public ResponseEntity<NoticeClientResponse> updateMeetNotice(
+            @Parameter(hidden = true) @SignUser AuthUserRequest user,
+            @PathVariable Long meetId,
+            @PathVariable Long noticeId,
+            @RequestBody @Valid NoticeUpdateRequest request
+    ) {
+        var body = noticeService.updateNotice(user.id(), meetId, noticeId, request);
 
         return ResponseEntity.ok()
                 .eTag("\"" + body.getVersion() + "\"")

--- a/src/main/java/com/mople/meet/controller/NoticeController.java
+++ b/src/main/java/com/mople/meet/controller/NoticeController.java
@@ -1,8 +1,16 @@
 package com.mople.meet.controller;
 
+import com.mople.core.annotation.auth.SignUser;
+import com.mople.dto.client.NoticeClientResponse;
+import com.mople.dto.request.meet.notice.NoticeCreateRequest;
+import com.mople.dto.request.user.AuthUserRequest;
 import com.mople.meet.service.notice.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,4 +21,20 @@ public class NoticeController {
 
     private final NoticeService noticeService;
 
+    @Operation(
+            summary = "공지 생성 API",
+            description = "모임장이 공지를 생성하고, 생성된 공지 정보를 반환합니다."
+    )
+    @PostMapping
+    public ResponseEntity<NoticeClientResponse> createMeetNotice(
+            @Parameter(hidden = true) @SignUser AuthUserRequest user,
+            @PathVariable Long meetId,
+            @RequestBody @Valid NoticeCreateRequest request
+    ) {
+        var body = noticeService.createNotice(user.id(), meetId, request);
+
+        return ResponseEntity.ok()
+                .eTag("\"" + body.getVersion() + "\"")
+                .body(body);
+    }
 }

--- a/src/main/java/com/mople/meet/repository/impl/notice/NoticeRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/notice/NoticeRepositorySupport.java
@@ -1,0 +1,60 @@
+package com.mople.meet.repository.impl.notice;
+
+import com.mople.entity.meet.notice.MeetNotice;
+import com.mople.entity.meet.notice.QMeetNotice;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NoticeRepositorySupport {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<MeetNotice> findNoticePage(Long meetId, Long cursorId, int size) {
+        QMeetNotice notice = QMeetNotice.meetNotice;
+
+        BooleanBuilder whereCondition = new BooleanBuilder()
+                .and(notice.meetId.eq(meetId));
+
+        if (cursorId != null) {
+            LocalDateTime cursorWriteTime = queryFactory
+                    .select(notice.createdAt)
+                    .from(notice)
+                    .where(notice.id.eq(cursorId))
+                    .fetchOne();
+
+            whereCondition.and(
+                    Expressions.booleanTemplate(
+                            "( {0}, {1} ) < ({2}, {3})",
+                            notice.createdAt, notice.id, cursorWriteTime, cursorId
+                    )
+            );
+        }
+
+        return queryFactory
+                .selectFrom(notice)
+                .where(whereCondition)
+                .orderBy(notice.createdAt.desc(), notice.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    public boolean isCursorInvalid(Long cursorId) {
+        QMeetNotice notice = QMeetNotice.meetNotice;
+
+        return queryFactory
+                .selectOne()
+                .from(notice)
+                .where(
+                        notice.id.eq(cursorId)
+                )
+                .fetchFirst() == null;
+    }
+}

--- a/src/main/java/com/mople/meet/repository/notice/NoticeRepository.java
+++ b/src/main/java/com/mople/meet/repository/notice/NoticeRepository.java
@@ -2,6 +2,10 @@ package com.mople.meet.repository.notice;
 
 import com.mople.entity.meet.notice.MeetNotice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NoticeRepository extends JpaRepository<MeetNotice, Long> {
+
+    @Query(value = "select version from meet where notice_id = :noticeId", nativeQuery = true)
+    long findVersion(Long noticeId);
 }

--- a/src/main/java/com/mople/meet/repository/notice/NoticeRepository.java
+++ b/src/main/java/com/mople/meet/repository/notice/NoticeRepository.java
@@ -1,0 +1,7 @@
+package com.mople.meet.repository.notice;
+
+import com.mople.entity.meet.notice.MeetNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<MeetNotice, Long> {
+}

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -1,15 +1,17 @@
 package com.mople.meet.service.notice;
 
-import com.mople.core.exception.custom.AuthException;
-import com.mople.core.exception.custom.BadRequestException;
-import com.mople.core.exception.custom.ConcurrencyConflictException;
-import com.mople.core.exception.custom.ResourceNotFoundException;
+import com.mople.core.exception.custom.*;
 import com.mople.dto.client.NoticeClientResponse;
 import com.mople.dto.request.meet.notice.NoticeCreateRequest;
 import com.mople.dto.request.meet.notice.NoticeUpdateRequest;
+import com.mople.dto.request.pagination.CursorPageRequest;
+import com.mople.dto.response.pagination.CursorPageResponse;
 import com.mople.entity.meet.Meet;
 import com.mople.entity.meet.notice.MeetNotice;
+import com.mople.global.utils.cursor.CursorUtils;
 import com.mople.meet.reader.EntityReader;
+import com.mople.meet.repository.MeetMemberRepository;
+import com.mople.meet.repository.impl.notice.NoticeRepositorySupport;
 import com.mople.meet.repository.notice.NoticeRepository;
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
@@ -18,15 +20,68 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.mople.dto.client.NoticeClientResponse.ofNotice;
 import static com.mople.global.enums.ExceptionReturnCode.*;
+import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
 
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
 
+    private static final int NOTICE_CURSOR_FIELD_COUNT = 1;
+
     private final EntityReader reader;
     private final NoticeRepository noticeRepository;
+    private final MeetMemberRepository memberRepository;
+    private final NoticeRepositorySupport noticeRepositorySupport;
+
+    @Transactional(readOnly = true)
+    public CursorPageResponse<NoticeClientResponse> getNoticeList(Long userId, Long meetId, CursorPageRequest request) {
+        reader.findUser(userId);
+        reader.findMeet(meetId);
+
+        if (!memberRepository.existsByMeetIdAndUserId(meetId, userId)) {
+            throw new AuthException(NOT_MEMBER);
+        }
+
+        int size = request.getSafeSize();
+        List<MeetNotice> notices = getNotices(meetId, request.cursor(), size);
+
+        return buildNoticeCursorPage(size, notices);
+    }
+
+    private List<MeetNotice> getNotices(Long meetId, String encodedCursor, int size) {
+
+        Long cursorId = null;
+
+        if (encodedCursor != null && !encodedCursor.isEmpty()) {
+            String[] decodeParts = CursorUtils.decode(encodedCursor, NOTICE_CURSOR_FIELD_COUNT);
+            cursorId = Long.valueOf(decodeParts[0]);
+
+            validateCursor(cursorId);
+        }
+
+        return noticeRepositorySupport.findNoticePage(meetId, cursorId, size);
+    }
+
+    private CursorPageResponse<NoticeClientResponse> buildNoticeCursorPage(int size, List<MeetNotice> notices) {
+        return buildCursorPage(
+                notices,
+                size,
+                n -> new String[]{
+                        n.getId().toString()
+                },
+                NoticeClientResponse::ofNotices
+        );
+    }
+
+    private void validateCursor(Long cursorId) {
+        if (noticeRepositorySupport.isCursorInvalid(cursorId)) {
+            throw new CursorException(INVALID_CURSOR);
+        }
+    }
 
     @Transactional
     public NoticeClientResponse createNotice(Long userId, NoticeCreateRequest request) {

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -1,0 +1,9 @@
+package com.mople.meet.service.notice;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+}

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -1,13 +1,19 @@
 package com.mople.meet.service.notice;
 
 import com.mople.core.exception.custom.AuthException;
+import com.mople.core.exception.custom.ConcurrencyConflictException;
+import com.mople.core.exception.custom.ResourceNotFoundException;
 import com.mople.dto.client.NoticeClientResponse;
 import com.mople.dto.request.meet.notice.NoticeCreateRequest;
+import com.mople.dto.request.meet.notice.NoticeUpdateRequest;
 import com.mople.entity.meet.Meet;
 import com.mople.entity.meet.notice.MeetNotice;
 import com.mople.meet.reader.EntityReader;
 import com.mople.meet.repository.notice.NoticeRepository;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.StaleObjectStateException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +39,35 @@ public class NoticeService {
         MeetNotice customNotice = noticeRepository.save(
                 MeetNotice.ofCustom(request.content(), userId, meetId)
         );
+
+        return ofNotice(customNotice);
+    }
+
+    @Transactional
+    public NoticeClientResponse updateNotice(Long userId, Long meetId, Long noticeId, NoticeUpdateRequest request) {
+        reader.findUser(userId);
+        Meet meet = reader.findMeet(meetId);
+
+        if (!meet.matchHost(userId)) {
+            throw new AuthException(NOT_HOST);
+        }
+
+        MeetNotice customNotice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_NOTICE));
+
+        customNotice.updateNotice(request.content());
+
+        try {
+            noticeRepository.flush();
+
+        } catch (
+                OptimisticLockException
+                | OptimisticLockingFailureException
+                | StaleObjectStateException e
+        ) {
+            long currentVersion = noticeRepository.findVersion(meet.getId());
+            throw new ConcurrencyConflictException(REQUEST_CONFLICT, currentVersion);
+        }
 
         return ofNotice(customNotice);
     }

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -1,9 +1,39 @@
 package com.mople.meet.service.notice;
 
+import com.mople.core.exception.custom.AuthException;
+import com.mople.dto.client.NoticeClientResponse;
+import com.mople.dto.request.meet.notice.NoticeCreateRequest;
+import com.mople.entity.meet.Meet;
+import com.mople.entity.meet.notice.MeetNotice;
+import com.mople.meet.reader.EntityReader;
+import com.mople.meet.repository.notice.NoticeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.mople.dto.client.NoticeClientResponse.ofNotice;
+import static com.mople.global.enums.ExceptionReturnCode.*;
 
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
+
+    private final EntityReader reader;
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public NoticeClientResponse createNotice(Long userId, Long meetId, NoticeCreateRequest request) {
+        reader.findUser(userId);
+        Meet meet = reader.findMeet(meetId);
+
+        if (!meet.matchHost(userId)) {
+            throw new AuthException(NOT_HOST);
+        }
+
+        MeetNotice customNotice = noticeRepository.save(
+                MeetNotice.ofCustom(request.content(), userId, meetId)
+        );
+
+        return ofNotice(customNotice);
+    }
 }

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -60,6 +60,10 @@ public class NoticeService {
         MeetNotice customNotice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_NOTICE));
 
+        if (!customNotice.getMeetId().equals(meetId)) {
+            throw new BadRequestException(NOT_FOUND_NOTICE);
+        }
+
         customNotice.updateNotice(request.content());
 
         try {
@@ -75,5 +79,21 @@ public class NoticeService {
         }
 
         return ofNotice(customNotice);
+    }
+
+    @Transactional
+    public void removeNotice(Long userId, Long noticeId) {
+        reader.findUser(userId);
+
+        MeetNotice customNotice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_NOTICE));
+
+        Meet meet = reader.findMeet(customNotice.getMeetId());
+
+        if (!meet.matchHost(userId)) {
+            throw new AuthException(NOT_HOST);
+        }
+
+        noticeRepository.delete(customNotice);
     }
 }

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -1,6 +1,7 @@
 package com.mople.meet.service.notice;
 
 import com.mople.core.exception.custom.AuthException;
+import com.mople.core.exception.custom.BadRequestException;
 import com.mople.core.exception.custom.ConcurrencyConflictException;
 import com.mople.core.exception.custom.ResourceNotFoundException;
 import com.mople.dto.client.NoticeClientResponse;
@@ -28,7 +29,9 @@ public class NoticeService {
     private final NoticeRepository noticeRepository;
 
     @Transactional
-    public NoticeClientResponse createNotice(Long userId, Long meetId, NoticeCreateRequest request) {
+    public NoticeClientResponse createNotice(Long userId, NoticeCreateRequest request) {
+        Long meetId = request.meetId();
+
         reader.findUser(userId);
         Meet meet = reader.findMeet(meetId);
 
@@ -44,7 +47,9 @@ public class NoticeService {
     }
 
     @Transactional
-    public NoticeClientResponse updateNotice(Long userId, Long meetId, Long noticeId, NoticeUpdateRequest request) {
+    public NoticeClientResponse updateNotice(Long userId, Long noticeId, NoticeUpdateRequest request) {
+        Long meetId = request.meetId();
+
         reader.findUser(userId);
         Meet meet = reader.findMeet(meetId);
 

--- a/src/main/java/com/mople/meet/service/notice/NoticeSystemService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeSystemService.java
@@ -1,0 +1,24 @@
+package com.mople.meet.service.notice;
+
+import com.mople.global.enums.notice.SystemNotice;
+import com.mople.meet.repository.notice.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.mople.entity.meet.notice.MeetNotice.ofSystem;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeSystemService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void publishSystemNotice(Long meetId, SystemNotice notice, Object... args) {
+        noticeRepository.save(
+                ofSystem(notice.format(args), meetId)
+        );
+    }
+}

--- a/src/main/java/com/mople/meet/service/plan/PlanService.java
+++ b/src/main/java/com/mople/meet/service/plan/PlanService.java
@@ -163,6 +163,7 @@ public class PlanService {
                         meet.getMeetImage(),
                         participantCount
                 ),
+                true,
                 commentRepositorySupport.countComment(plan.getId()));
     }
 
@@ -229,6 +230,7 @@ public class PlanService {
                         meet.getMeetImage(),
                         participantCount
                 ),
+                true,
                 commentRepositorySupport.countComment(plan.getId()));
     }
 
@@ -281,7 +283,7 @@ public class PlanService {
 
         Integer participantCount = participantRepository.countByPlanId(plan.getId());
 
-        return ofViewAndParticipant(
+        return ofView(
                 ofPlanView(
                         plan,
                         meet.getName(),


### PR DESCRIPTION
## 모임 공지 기능 추가, 일부 api에 참여 여부 포함
---
### 모임 공지 기능 추가

알림을 수신 거부해 놓은 사용자를 위한 모임 히스토리를 저장하는 모임 공지 기능을 추가했습니다.

모임장만 작성할 수 있고,
모임장이 직접 작성하는 커스텀 `MeetNotice`와
`HostChanged`, `MeetJoined` 이벤트가 발생하면 서버가 생성하는 시스템 `MeetNotice`가 있습니다!!

공지 생성, 공지 수정, 공지 삭제, 공지 페이징 조회 api를 추가하였습니다!!

---
### 일부 api에 참여 여부 포함

- 홈 대시보드 api
- 일정 생성 api
- 일정 수정 api

위 api에서는 응답 DTO에 참여 여부를 알려주는 `participant` 값이 항상 `true`이기 때문에 값을 추가해주었습니다!!

---

공지 기능에서 디테일 한 부분은 아직 정해지지 않아 추후에 요구사항이 명확해지면 변경/추가할 부분이 있을 수도 있습니다!
우선은 모임장이 사용할 간단한 crud 기능과, 서버에서 직접 `notice`를 추가하는 핵심 기능만 구현했습니다!!

시간 편하실 때 천천히 확인해주시면 감사하겠습니다 😊
항상 감사합니다 대영님!!
(그리고 `dockerfile` 이미지 태그 수정해서 배포 성공확인했습니다 🫡🫡)
