### PR TITLE
Feat/meeting notice

### DIFF
--- a/src/main/java/com/mople/dto/event/data/notify/comment/CommentMentionNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/comment/CommentMentionNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record CommentMentionNotifyEvent(
         String meetName,
@@ -18,7 +20,7 @@ public record CommentMentionNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 새로운 멘션 👀",
+                highlight(meetName) + "의 새로운 멘션 👀",
                 meetName + "에서 " + senderNickname + "님이 회원님을 멘션했어요!"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/comment/CommentReplyNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/comment/CommentReplyNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record CommentReplyNotifyEvent(
         String meetName,
@@ -18,7 +20,7 @@ public record CommentReplyNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 새로운 대댓글 👀",
+                highlight(meetName) + "의 새로운 대댓글 👀",
                 meetName + "에서 " + senderNickname + "님이 답글을 남겼어요!"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/meet/MeetJoinNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/meet/MeetJoinNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record MeetJoinNotifyEvent(
         Long meetId,
@@ -17,7 +19,7 @@ public record MeetJoinNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 새 멤버 \uD83C\uDF89",
+                highlight(meetName) + "의 새 멤버 \uD83C\uDF89",
                 newMemberNickname + "님이 가입했어요!"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/plan/PlanCreateNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/plan/PlanCreateNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record PlanCreateNotifyEvent(
         String meetName,
@@ -17,7 +19,7 @@ public record PlanCreateNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 일정등록 \uD83D\uDCC6",
+                highlight(meetName) + "의 일정등록 \uD83D\uDCC6",
                 planName + "에 참여해보세요!"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/plan/PlanDeleteNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/plan/PlanDeleteNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record PlanDeleteNotifyEvent(
         Long meetId,
@@ -17,7 +19,7 @@ public record PlanDeleteNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 일정취소",
+                highlight(meetName) + "의 일정취소",
                 planName + " 일정이 취소됐어요"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/plan/PlanNoLocationNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/plan/PlanNoLocationNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record PlanNoLocationNotifyEvent(
         String meetName,
@@ -17,7 +19,7 @@ public record PlanNoLocationNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 약속장소를 정하지 않았어요! 🙈",
+                highlight(meetName) + "의 약속장소를 정하지 않았어요! 🙈",
                 planName + " 장소 확정이 필요해요"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/plan/PlanRemindNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/plan/PlanRemindNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record PlanRemindNotifyEvent(
         String meetName,
@@ -17,7 +19,7 @@ public record PlanRemindNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 일정 알림 ⏰",
+                highlight(meetName) + "의 일정 알림 ⏰",
                 planName + " 곧 시작돼요!"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/plan/PlanUpdateNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/plan/PlanUpdateNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record PlanUpdateNotifyEvent(
         String meetName,
@@ -17,7 +19,7 @@ public record PlanUpdateNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 일정변경",
+                highlight(meetName) + "의 일정변경",
                 planName + " 일정이 변경됐어요"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/review/ReviewRemindNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/review/ReviewRemindNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record ReviewRemindNotifyEvent(
         String meetName,
@@ -17,7 +19,7 @@ public record ReviewRemindNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 일정은 어떠셨나요?",
+                highlight(meetName) + "의 일정은 어떠셨나요?",
                 reviewName + "의 사진을 공유해보세요"
         );
     }

--- a/src/main/java/com/mople/dto/event/data/notify/review/ReviewUploadNotifyEvent.java
+++ b/src/main/java/com/mople/dto/event/data/notify/review/ReviewUploadNotifyEvent.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 
 import java.util.Map;
 
+import static com.mople.global.utils.text.HighlightUtils.highlight;
+
 @Builder
 public record ReviewUploadNotifyEvent(
         String meetName,
@@ -17,7 +19,7 @@ public record ReviewUploadNotifyEvent(
     @Override
     public NotificationPayload payload() {
         return new NotificationPayload(
-                meetName + "의 일정은 어떠셨나요?",
+                highlight(meetName) + "의 일정은 어떠셨나요?",
                 reviewName + "의 사진을 확인해보세요"
         );
     }

--- a/src/main/java/com/mople/global/utils/text/HighlightUtils.java
+++ b/src/main/java/com/mople/global/utils/text/HighlightUtils.java
@@ -1,0 +1,7 @@
+package com.mople.global.utils.text;
+
+public class HighlightUtils {
+    public static String highlight(String text) {
+        return "<highlight>" + text + "</highlight>";
+    }
+}

--- a/src/main/java/com/mople/meet/controller/CommentController.java
+++ b/src/main/java/com/mople/meet/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.mople.meet.controller;
 
 import com.mople.core.annotation.auth.SignUser;
 import com.mople.dto.client.CommentClientResponse;
+import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.request.meet.comment.CommentUpdateRequest;
 import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
@@ -11,6 +12,7 @@ import com.mople.meet.service.comment.CommentService;
 import com.mople.dto.request.meet.comment.CommentCreateRequest;
 import com.mople.dto.request.meet.comment.CommentReportRequest;
 
+import com.mople.meet.service.meet.MeetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "COMMENT", description = "댓글 API")
 public class CommentController {
     private final CommentService commentService;
+    private final MeetService meetService;
 
     @Operation(
             summary = "댓글 조회 API",
@@ -145,5 +148,20 @@ public class CommentController {
     ) {
         commentService.commentReport(user.id(), CommentReportRequest);
         return ResponseEntity.ok().build();
+    }
+
+    // 과거에 배포된 url
+    @Operation(
+            summary = "멘션 자동 완성 API",
+            description = "입력한 키워드에 맞는 모임 멤버 닉네임을 자동 완성합니다."
+    )
+    @GetMapping("/{postId}/mention")
+    public CursorPageResponse<UserRoleClientResponse> searchMention(
+            @Parameter(hidden = true) @SignUser AuthUserRequest user,
+            @PathVariable Long postId,
+            @RequestParam String keyword,
+            @ParameterObject @Valid CursorPageRequest request
+    ) {
+        return meetService.searchMeetMember(user.id(), postId, keyword, request);
     }
 }


### PR DESCRIPTION
## 알림 문구에 하이라이트 태그 추가, 멘션 자동완성 api 과거 url 살려놓기
---
### 알림 문구에 하이라이트 태그 추가

알림 리스트에서 사용되는 문구 중에 클라이언트에서 `meetName` 같은 부분에 폰트 효과를 주기 위해
 `HighlightUtils`를 만들어 `meetName` 에   `<highlight>` 태그를 붙여 저장하도록 하였습니다!

---
### 멘션 자동완성 api 과거 url 살려놓기

멘션 자동완성 api 를 과거 `comment`에서 `meet`로 옮겼었습니다!
(해당 api 를 댓글 자동완성 외에도 모임장 양도 기능에서도 사용할 것이기 때문에)

강제 업데이트를 할 계획으로 과거 url을 가진 api 를 삭제했었으나,
하나의 api 만 이동된 것이기 때문에 우선은 과거 api 를 복구하였고,
추후 강제 업데이트 예정 시에 해당 로직 정리하겠습니다!

과거 api 를 남기는 이유는 업데이트 전 과거 url 을 사용하는 버전은 에러가 뜨기 때문에 `강제 업데이트` or `과거 api 살리기` 를 해야 했습니다....!!

---

이번 pr 은 간단합니다 대영님...!!
천천히 확인해주시고, 궁금하신 점 있으면 언제나처럼 편하게 말씀주세요 !! 🫡🫡
 