### PR TITLE
Refactor/status code

### DIFF
--- a/src/main/java/com/mople/global/enums/ExceptionReturnCode.java
+++ b/src/main/java/com/mople/global/enums/ExceptionReturnCode.java
@@ -30,16 +30,16 @@ public enum ExceptionReturnCode {
     FORCE_UPDATE("426", "업데이트가 필요합니다."),
 
     // Meet
-    NOT_CREATOR("401", "접근 권한이 없습니다."),
-    NOT_HOST("401", "접근 권한이 없습니다."),
-    UNAUTHORIZED_DELETE("401", "삭제 권한이 없습니다."),
+    NOT_CREATOR("403", "접근 권한이 없습니다."),
+    NOT_HOST("403", "접근 권한이 없습니다."),
+    UNAUTHORIZED_DELETE("403", "삭제 권한이 없습니다."),
     NOT_FOUND_MEET("404", "모임을 찾을 수 없습니다."),
     INVALID_INVITE_CODE("400", "유효하지 않은 초대 코드입니다."),
     CURRENT_MEMBER("400", "이미 존재하는 멤버입니다."),
     CURRENT_HOST("400", "현재 모임장입니다."),
     NOT_FOUND_MEMBER("404", "멤버를 찾을 수 없습니다."),
     NOT_FOUND_INVITE("404", "모임 초대정보를 찾을 수 없습니다."),
-    NOT_MEMBER("401", "접근 권한이 없습니다."),
+    NOT_MEMBER("403", "접근 권한이 없습니다."),
 
     // Post
     NOT_FOUND_POST("404", "게시글을 찾을 수 없습니다."),
@@ -47,7 +47,7 @@ public enum ExceptionReturnCode {
     // Plan
     NOT_FOUND_PLAN("404", "일정을 찾을 수 없습니다."),
     CURRENT_PARTICIPANT("400", "이미 존재하는 멤버입니다."),
-    NOT_PARTICIPANT("401", "일정에 참가한 유저만 접근할 수 있습니다."),
+    NOT_PARTICIPANT("403", "일정에 참가한 유저만 접근할 수 있습니다."),
 
     // Review
     CURRENT_REVIEW("400", "이미 후기가 존재합니다."),
@@ -77,7 +77,7 @@ public enum ExceptionReturnCode {
     // Notification
     NOT_FOUND_NOTIFY("404", "알림을 찾을 수 없습니다."),
     NOT_FOUND_NOTIFY_TYPE("400", "지원하지 않는 알림 유형입니다."),
-    NOT_OWNER_OF_NOTIFICATION("401", "접근 권한이 없습니다."),
+    NOT_OWNER_OF_NOTIFICATION("403", "접근 권한이 없습니다."),
 
     // Request
     WRONG_PARAMETER("400", "잘못된 파라미터 입니다."),

--- a/src/main/java/com/mople/global/enums/ExceptionReturnCode.java
+++ b/src/main/java/com/mople/global/enums/ExceptionReturnCode.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum ExceptionReturnCode {
-    // 인증, 인가 관련
+
+    // Auth
     INVALID_KEY("400", "잘못된 KEY 입니다"),
     EXPIRED_JWT_TOKEN("400", "만료된 JWT 입니다."),
     EXPIRED_REFRESH_TOKEN("401", "재 인증이 필요합니다."),
@@ -17,10 +18,9 @@ public enum ExceptionReturnCode {
     ANOTHER_PROVIDER("400", "로그인 제공자가 다릅니다."),
     TOKEN_NOT_VALID("400", "ID TOKEN 인증에 실패하였습니다."),
     DUPLICATE_NICKNAME("403", "중복된 닉네임입니다."),
-    NOT_USER("404", "유저 정보가 없습니다."),
-    INVALID_USER("400", "유효하지 않은 유저입니다."),
+    NOT_FOUND_USER("404", "유저 정보가 없습니다."),
 
-    // 정책 관련
+    // Policy
     EMPTY_OS("400", "운영체제가 존재하지 않습니다."),
     EMPTY_VERSION("400", "버전이 존재하지 않습니다."),
     UNSUPPORTED_OS("400", "유효하지 않은 운영체제입니다."),
@@ -40,10 +40,6 @@ public enum ExceptionReturnCode {
     NOT_FOUND_MEMBER("404", "멤버를 찾을 수 없습니다."),
     NOT_FOUND_INVITE("404", "모임 초대정보를 찾을 수 없습니다."),
     NOT_MEMBER("401", "접근 권한이 없습니다."),
-    INVALID_MEET("400", "유효하지 않은 모임입니다."),
-
-    // TIME
-    NOT_FOUND_TIME("404", "일정의 시간을 찾을 수 없습니다."),
 
     // Post
     NOT_FOUND_POST("404", "게시글을 찾을 수 없습니다."),
@@ -51,30 +47,25 @@ public enum ExceptionReturnCode {
     // Plan
     NOT_FOUND_PLAN("404", "일정을 찾을 수 없습니다."),
     CURRENT_PARTICIPANT("400", "이미 존재하는 멤버입니다."),
-    NOT_FOUND_PARTICIPANT("404", "멤버를 찾을 수 없습니다."),
     NOT_PARTICIPANT("401", "일정에 참가한 유저만 접근할 수 있습니다."),
-    INVALID_PLAN("400", "유효하지 않은 일정입니다."),
 
-    // review
+    // Review
     CURRENT_REVIEW("400", "이미 후기가 존재합니다."),
     NOT_FOUND_REVIEW("404", "후기를 찾을 수 없습니다."),
-    NOT_FOUND_REVIEW_IMAGE("404", "이미지를 찾을 수 없습니다."),
-    INVALID_REVIEW("400", "유효하지 않은 후기입니다."),
 
-    // comment
+    // Comment
     NOT_FOUND_COMMENT("404", "댓글을 찾을 수 없습니다."),
     NOT_PARENT_COMMENT("400", "부모 댓글이 아닙니다."),
     NOT_FOUND_COMMENT_STATS("404", "댓글 정보를 찾을 수 없습니다."),
-    INVALID_COMMENT("400", "유효하지 않은 댓글입니다."),
 
-    // notice
+    // Notice
     NOT_FOUND_NOTICE("404", "공지를 찾을 수 없습니다."),
 
-    // cursor
+    // Cursor
     INVALID_CURSOR("400", "잘못된 커서입니다."),
     FAIL_DECODING_CURSOR("400", "커서를 디코딩할 수 없습니다."),
 
-    // report
+    // Report
     CURRENT_REPORT("400", "이미 신고가 존재합니다."),
 
     // Image
@@ -88,12 +79,12 @@ public enum ExceptionReturnCode {
     NOT_FOUND_NOTIFY_TYPE("400", "지원하지 않는 알림 유형입니다."),
     NOT_OWNER_OF_NOTIFICATION("401", "접근 권한이 없습니다."),
 
-    // 요청 관련
+    // Request
     WRONG_PARAMETER("400", "잘못된 파라미터 입니다."),
     METHOD_NOT_ALLOWED("405", "허용되지 않은 메소드 입니다."),
     REQUEST_CONFLICT("409", "새로고침 후 다시 시도해주세요."),
 
-    // 내부 에러
+    // Server Error
     INTERNAL_SERVER_ERROR("500", "내부 서버 에러 입니다."),
     EXTERNAL_SERVER_ERROR("500", "외부 서버 에러 입니다."),
     ILLEGAL_HANDLER_TYPE("500", "핸들러를 처리할 수 없습니다."),

--- a/src/main/java/com/mople/global/event/handler/domain/impl/comment/create/CommentMentionNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/comment/create/CommentMentionNotifier.java
@@ -56,7 +56,7 @@ public class CommentMentionNotifier implements DomainEventHandler<CommentCreated
         }
 
         User sender = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_USER));
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_USER));
 
         CommentMentionNotifyEvent.CommentMentionNotifyEventBuilder eventBuilder = CommentMentionNotifyEvent.builder()
                 .meetName(postContext.getMeet().getName())

--- a/src/main/java/com/mople/global/event/handler/domain/impl/comment/create/CommentReplyNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/comment/create/CommentReplyNotifier.java
@@ -55,7 +55,7 @@ public class CommentReplyNotifier implements DomainEventHandler<CommentCreatedEv
         }
 
         User sender = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_USER));
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_USER));
 
         if (event.isExistMention()) {
             List<Long> mentionedUsers = userReader.findCreatedMentionedUsers(

--- a/src/main/java/com/mople/global/event/handler/domain/impl/comment/update/CommentUpdateMentionNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/comment/update/CommentUpdateMentionNotifier.java
@@ -50,7 +50,7 @@ public class CommentUpdateMentionNotifier implements DomainEventHandler<CommentM
         }
 
         User sender = userRepository.findByIdAndStatus(event.commentWriterId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_USER));
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_USER));
 
         CommentMentionNotifyEvent.CommentMentionNotifyEventBuilder eventBuilder = CommentMentionNotifyEvent.builder()
                 .meetName(postContext.getMeet().getName())

--- a/src/main/java/com/mople/global/event/handler/domain/impl/meet/join/MeetJoinNotifier.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/meet/join/MeetJoinNotifier.java
@@ -51,7 +51,7 @@ public class MeetJoinNotifier implements DomainEventHandler<MeetJoinedEvent> {
                 .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_MEET));
 
         User user = userRepository.findByIdAndStatus(event.newMemberId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_USER));
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_USER));
 
         MeetJoinNotifyEvent notifyEvent = MeetJoinNotifyEvent.builder()
                 .meetId(event.meetId())

--- a/src/main/java/com/mople/global/event/service/PostContextFinder.java
+++ b/src/main/java/com/mople/global/event/service/PostContextFinder.java
@@ -30,16 +30,16 @@ public class PostContextFinder {
             MeetPlan plan = planOptional.get();
 
             Meet meet = meetRepository.findByIdAndStatus(plan.getMeetId(), Status.ACTIVE)
-                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
+                    .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_PLAN));
 
             return PostContext.plan(meet, plan);
         }
 
         PlanReview review = reviewRepository.findByPlanIdAndStatus(postId, Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_REVIEW));
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_REVIEW));
 
         Meet meet = meetRepository.findByIdAndStatus(review.getMeetId(), Status.ACTIVE)
-                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.INVALID_MEET));
+                .orElseThrow(() -> new NonRetryableOutboxException(ExceptionReturnCode.NOT_FOUND_MEET));
 
         return PostContext.review(meet, review);
     }

--- a/src/main/java/com/mople/global/utils/cursor/custom/UserCursor.java
+++ b/src/main/java/com/mople/global/utils/cursor/custom/UserCursor.java
@@ -4,14 +4,16 @@ import com.mople.entity.meet.MeetMember;
 import com.mople.entity.meet.plan.PlanParticipant;
 
 public record UserCursor(
+        Integer deletedOrder,
         Integer roleOrder,
         Integer nicknameTypeOrder,
         String nicknameLower,
         Long id
 ) {
 
-    public static UserCursor ofUserCursor(MeetMember member) {
+    public static UserCursor forMeetMember(MeetMember member) {
         return new UserCursor(
+                0,
                 member.getRoleOrder(),
                 member.getNicknameTypeOrder(),
                 member.getNicknameLower(),
@@ -19,8 +21,19 @@ public record UserCursor(
         );
     }
 
-    public static UserCursor ofUserCursor(PlanParticipant participant) {
+    public static UserCursor forPlan(PlanParticipant participant) {
         return new UserCursor(
+                0,
+                participant.getRoleOrder(),
+                participant.getNicknameTypeOrder(),
+                participant.getNicknameLower(),
+                participant.getId()
+        );
+    }
+
+    public static UserCursor forReview(PlanParticipant participant, int deletedOrder) {
+        return new UserCursor(
+                deletedOrder,
                 participant.getRoleOrder(),
                 participant.getNicknameTypeOrder(),
                 participant.getNicknameLower(),

--- a/src/main/java/com/mople/global/utils/cursor/custom/sort/MemberSortExpressions.java
+++ b/src/main/java/com/mople/global/utils/cursor/custom/sort/MemberSortExpressions.java
@@ -1,6 +1,8 @@
 package com.mople.global.utils.cursor.custom.sort;
 
 import com.mople.entity.meet.QMeetMember;
+import com.mople.entity.user.QUser;
+import com.mople.global.enums.Status;
 import com.mople.global.enums.UserRole;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
@@ -19,6 +21,20 @@ public class MemberSortExpressions {
         }
 
         return 2;
+    }
+
+    public static NumberExpression<Integer> deletedOrder(QUser user) {
+        return new CaseBuilder()
+                        .when(user.status.eq(Status.DELETED)).then(1)
+                        .otherwise(0);
+    }
+
+    public static Integer deletedOrder(Status status) {
+        if (status.equals(Status.DELETED)) {
+            return 1;
+        }
+
+        return 0;
     }
 
     public static Integer calculateRoleOrder(Long userId, Long hostId, Long creatorId) {

--- a/src/main/java/com/mople/global/utils/cursor/custom/sort/MemberSortExpressions.java
+++ b/src/main/java/com/mople/global/utils/cursor/custom/sort/MemberSortExpressions.java
@@ -1,11 +1,13 @@
 package com.mople.global.utils.cursor.custom.sort;
 
 import com.mople.entity.meet.QMeetMember;
-import com.mople.entity.user.QUser;
+import com.mople.entity.meet.plan.QPlanParticipant;
 import com.mople.global.enums.Status;
 import com.mople.global.enums.UserRole;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
+
+import java.util.List;
 
 public class MemberSortExpressions {
 
@@ -23,9 +25,9 @@ public class MemberSortExpressions {
         return 2;
     }
 
-    public static NumberExpression<Integer> deletedOrder(QUser user) {
+    public static NumberExpression<Integer> deletedOrder(QPlanParticipant participant, List<Long> deletedIds) {
         return new CaseBuilder()
-                        .when(user.status.eq(Status.DELETED)).then(1)
+                        .when(participant.userId.in(deletedIds)).then(1)
                         .otherwise(0);
     }
 

--- a/src/main/java/com/mople/meet/controller/CommentController.java
+++ b/src/main/java/com/mople/meet/controller/CommentController.java
@@ -2,7 +2,6 @@ package com.mople.meet.controller;
 
 import com.mople.core.annotation.auth.SignUser;
 import com.mople.dto.client.CommentClientResponse;
-import com.mople.dto.client.UserRoleClientResponse;
 import com.mople.dto.request.meet.comment.CommentUpdateRequest;
 import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
@@ -12,7 +11,6 @@ import com.mople.meet.service.comment.CommentService;
 import com.mople.dto.request.meet.comment.CommentCreateRequest;
 import com.mople.dto.request.meet.comment.CommentReportRequest;
 
-import com.mople.meet.service.meet.MeetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,7 +29,6 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "COMMENT", description = "댓글 API")
 public class CommentController {
     private final CommentService commentService;
-    private final MeetService meetService;
 
     @Operation(
             summary = "댓글 조회 API",
@@ -148,20 +145,5 @@ public class CommentController {
     ) {
         commentService.commentReport(user.id(), CommentReportRequest);
         return ResponseEntity.ok().build();
-    }
-
-    // 과거에 배포된 url
-    @Operation(
-            summary = "멘션 자동 완성 API",
-            description = "입력한 키워드에 맞는 모임 멤버 닉네임을 자동 완성합니다."
-    )
-    @GetMapping("/{postId}/mention")
-    public CursorPageResponse<UserRoleClientResponse> searchMention(
-            @Parameter(hidden = true) @SignUser AuthUserRequest user,
-            @PathVariable Long postId,
-            @RequestParam String keyword,
-            @ParameterObject @Valid CursorPageRequest request
-    ) {
-        return meetService.searchMeetMember(user.id(), postId, keyword, request);
     }
 }

--- a/src/main/java/com/mople/meet/reader/EntityReader.java
+++ b/src/main/java/com/mople/meet/reader/EntityReader.java
@@ -1,7 +1,6 @@
 package com.mople.meet.reader;
 
 import com.mople.core.exception.custom.AuthException;
-import com.mople.core.exception.custom.BadRequestException;
 import com.mople.core.exception.custom.ResourceNotFoundException;
 import com.mople.entity.meet.Meet;
 import com.mople.entity.meet.comment.PlanComment;
@@ -30,68 +29,32 @@ public class EntityReader {
     private final PlanCommentRepository commentRepository;
 
     public User findUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new AuthException(NOT_USER));
-
-        if (user.getStatus() == Status.ACTIVE) {
-            return user;
-        }
-
-        throw new BadRequestException(INVALID_USER);
+        return userRepository.findByIdAndStatus(userId, Status.ACTIVE)
+                .orElseThrow(() -> new AuthException(NOT_FOUND_USER));
     }
 
     public Meet findMeet(Long meetId) {
-        Meet meet = meetRepository.findById(meetId)
+        return meetRepository.findByIdAndStatus(meetId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_MEET));
-
-        if (meet.getStatus() == Status.ACTIVE) {
-            return meet;
-        }
-
-        throw new BadRequestException(INVALID_MEET);
     }
 
     public MeetPlan findPlan(Long planId) {
-        MeetPlan plan = planRepository.findById(planId)
+        return planRepository.findByIdAndStatus(planId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_PLAN));
-
-        if (plan.getStatus() == Status.ACTIVE) {
-            return plan;
-        }
-
-        throw new BadRequestException(INVALID_PLAN);
     }
 
     public PlanReview findReview(Long reviewId) {
-        PlanReview review = planReviewRepository.findById(reviewId)
+        return planReviewRepository.findByIdAndStatus(reviewId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_REVIEW));
-
-        if (review.getStatus() == Status.ACTIVE) {
-            return review;
-        }
-
-        throw new BadRequestException(INVALID_REVIEW);
     }
 
     public PlanReview findReviewByPostId(Long postId) {
-        PlanReview review = planReviewRepository.findReviewByPostId(postId)
+        return planReviewRepository.findByPlanIdAndStatus(postId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_REVIEW));
-
-        if (review.getStatus() == Status.ACTIVE) {
-            return review;
-        }
-
-        throw new BadRequestException(INVALID_REVIEW);
     }
 
     public PlanComment findComment(Long commentId) {
-        PlanComment comment = commentRepository.findById(commentId)
+        return commentRepository.findByIdAndStatus(commentId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_COMMENT));
-
-        if (comment.getStatus() == Status.ACTIVE) {
-            return comment;
-        }
-
-        throw new BadRequestException(INVALID_COMMENT);
     }
 }

--- a/src/main/java/com/mople/meet/repository/comment/PlanCommentRepository.java
+++ b/src/main/java/com/mople/meet/repository/comment/PlanCommentRepository.java
@@ -5,11 +5,10 @@ import com.mople.global.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface PlanCommentRepository extends JpaRepository<PlanComment, Long> {
 
@@ -29,6 +28,9 @@ public interface PlanCommentRepository extends JpaRepository<PlanComment, Long> 
 
     @Query("select c.id from PlanComment c where c.postId = :postId and c.status = com.mople.global.enums.Status.ACTIVE")
     List<Long> findIdByPostId(Long postId);
+
+    @Query("select c from PlanComment c where c.id = :id and c.status = :status")
+    Optional<PlanComment> findByIdAndStatus(Long id, Status status);
 
     @Modifying(flushAutomatically = true)
     @Query(

--- a/src/main/java/com/mople/meet/repository/impl/MeetMemberRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/MeetMemberRepositorySupport.java
@@ -28,7 +28,7 @@ public class MeetMemberRepositorySupport {
         if (cursor != null) {
             whereCondition.and(
                     Expressions.booleanTemplate(
-                            "( {0}, {1}, {2}, {3} ) > ({4}, {5}, {6}, {7})",
+                            "( {0}, {1}, {2}, {3} ) > ( {4}, {5}, {6}, {7} )",
                             member.roleOrder, member.nicknameTypeOrder, member.nicknameLower, member.id,
                             cursor.roleOrder(), cursor.nicknameTypeOrder(), cursor.nicknameLower(), cursor.id()
                     )

--- a/src/main/java/com/mople/meet/repository/impl/comment/CommentRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/comment/CommentRepositorySupport.java
@@ -34,7 +34,7 @@ public class CommentRepositorySupport {
 
             whereCondition.and(
                     Expressions.booleanTemplate(
-                            "( {0}, {1} ) < ({2}, {3})",
+                            "( {0}, {1} ) < ( {2}, {3} )",
                             comment.writeTime, comment.id, cursorWriteTime, cursorId
                     )
             );

--- a/src/main/java/com/mople/meet/repository/impl/notice/NoticeRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/notice/NoticeRepositorySupport.java
@@ -32,7 +32,7 @@ public class NoticeRepositorySupport {
 
             whereCondition.and(
                     Expressions.booleanTemplate(
-                            "( {0}, {1} ) < ({2}, {3})",
+                            "( {0}, {1} ) < ( {2}, {3} )",
                             notice.createdAt, notice.id, cursorWriteTime, cursorId
                     )
             );

--- a/src/main/java/com/mople/meet/repository/impl/plan/ParticipantRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/plan/ParticipantRepositorySupport.java
@@ -1,6 +1,7 @@
 package com.mople.meet.repository.impl.plan;
 
 import com.mople.entity.user.QUser;
+import com.mople.global.enums.Status;
 import com.mople.global.utils.cursor.custom.UserCursor;
 import com.mople.entity.meet.plan.PlanParticipant;
 import com.mople.entity.meet.plan.QPlanParticipant;
@@ -51,11 +52,10 @@ public class ParticipantRepositorySupport {
                 .fetch();
     }
 
-    public List<PlanParticipant> findReviewParticipantPage(Long reviewId, UserCursor cursor, int size) {
+    public List<PlanParticipant> findReviewParticipantPage(Long reviewId, UserCursor cursor, int size, List<Long> deletedIds) {
         QPlanParticipant participant = QPlanParticipant.planParticipant;
-        QUser user = QUser.user;
 
-        NumberExpression<Integer> deletedOrder = deletedOrder(user);
+        NumberExpression<Integer> deletedOrder = deletedOrder(participant, deletedIds);
 
         BooleanBuilder whereCondition = new BooleanBuilder()
                 .and(participant.reviewId.eq(reviewId));
@@ -83,7 +83,6 @@ public class ParticipantRepositorySupport {
         return queryFactory
                 .select(participant)
                 .from(participant)
-                .join(user).on(participant.userId.eq(user.id))
                 .where(whereCondition)
                 .orderBy(
                         deletedOrder.asc(),
@@ -143,5 +142,20 @@ public class ParticipantRepositorySupport {
                         )
                         .fetch()
         );
+    }
+
+    public List<Long> findDeletedUserIdsByReviewId(Long reviewId) {
+        QPlanParticipant participant = QPlanParticipant.planParticipant;
+        QUser user = QUser.user;
+
+        return queryFactory
+                .select(participant.userId)
+                .from(participant)
+                .join(user).on(participant.userId.eq(user.id))
+                .where(
+                        participant.reviewId.eq(reviewId),
+                        user.status.eq(Status.DELETED)
+                )
+                .fetch();
     }
 }

--- a/src/main/java/com/mople/meet/repository/impl/plan/ParticipantRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/plan/ParticipantRepositorySupport.java
@@ -26,7 +26,7 @@ public class ParticipantRepositorySupport {
         if (cursor != null) {
             whereCondition.and(
                     Expressions.booleanTemplate(
-                            "( {0}, {1}, {2}, {3} ) > ({4}, {5}, {6}, {7})",
+                            "( {0}, {1}, {2}, {3} ) > ( {4}, {5}, {6}, {7} )",
                             participant.roleOrder, participant.nicknameTypeOrder, participant.nicknameLower, participant.id,
                             cursor.roleOrder(), cursor.nicknameTypeOrder(), cursor.nicknameLower(), cursor.id()
                     )

--- a/src/main/java/com/mople/meet/repository/impl/plan/ParticipantRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/plan/ParticipantRepositorySupport.java
@@ -1,16 +1,20 @@
 package com.mople.meet.repository.impl.plan;
 
+import com.mople.entity.user.QUser;
 import com.mople.global.utils.cursor.custom.UserCursor;
 import com.mople.entity.meet.plan.PlanParticipant;
 import com.mople.entity.meet.plan.QPlanParticipant;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.mople.global.utils.cursor.custom.sort.MemberSortExpressions.deletedOrder;
 
 @Repository
 @RequiredArgsConstructor
@@ -49,6 +53,9 @@ public class ParticipantRepositorySupport {
 
     public List<PlanParticipant> findReviewParticipantPage(Long reviewId, UserCursor cursor, int size) {
         QPlanParticipant participant = QPlanParticipant.planParticipant;
+        QUser user = QUser.user;
+
+        NumberExpression<Integer> deletedOrder = deletedOrder(user);
 
         BooleanBuilder whereCondition = new BooleanBuilder()
                 .and(participant.reviewId.eq(reviewId));
@@ -56,9 +63,19 @@ public class ParticipantRepositorySupport {
         if (cursor != null) {
             whereCondition.and(
                     Expressions.booleanTemplate(
-                            "( {0}, {1}, {2}, {3} ) > ({4}, {5}, {6}, {7})",
-                            participant.roleOrder, participant.nicknameTypeOrder, participant.nicknameLower, participant.id,
-                            cursor.roleOrder(), cursor.nicknameTypeOrder(), cursor.nicknameLower(), cursor.id()
+                            "( {0}, {1}, {2}, {3}, {4} ) > ( {5}, {6}, {7}, {8}, {9} )",
+
+                            deletedOrder,
+                            participant.roleOrder,
+                            participant.nicknameTypeOrder,
+                            participant.nicknameLower,
+                            participant.id,
+
+                            cursor.deletedOrder(),
+                            cursor.roleOrder(),
+                            cursor.nicknameTypeOrder(),
+                            cursor.nicknameLower(),
+                            cursor.id()
                     )
             );
         }
@@ -66,8 +83,10 @@ public class ParticipantRepositorySupport {
         return queryFactory
                 .select(participant)
                 .from(participant)
+                .join(user).on(participant.userId.eq(user.id))
                 .where(whereCondition)
                 .orderBy(
+                        deletedOrder.asc(),
                         participant.roleOrder.asc(),
                         participant.nicknameTypeOrder.asc().nullsLast(),
                         participant.nicknameLower.asc(),

--- a/src/main/java/com/mople/meet/repository/impl/plan/PlanRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/plan/PlanRepositorySupport.java
@@ -108,7 +108,7 @@ public class PlanRepositorySupport {
 
             whereCondition.and(
                     Expressions.booleanTemplate(
-                            "( {0}, {1} ) > ({2}, {3})",
+                            "( {0}, {1} ) > ( {2}, {3} )",
                             plan.planTime, plan.id, cursorPlanTime, cursorId
                     )
             );

--- a/src/main/java/com/mople/meet/repository/impl/review/ReviewRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/review/ReviewRepositorySupport.java
@@ -33,7 +33,7 @@ public class ReviewRepositorySupport {
 
             whereCondition.and(
                     Expressions.booleanTemplate(
-                            "( {0}, {1} ) < ({2}, {3})",
+                            "( {0}, {1} ) < ( {2}, {3} )",
                             review.planTime, review.id, cursorPlanTime, cursorId
                     )
             );

--- a/src/main/java/com/mople/meet/repository/review/PlanReviewRepository.java
+++ b/src/main/java/com/mople/meet/repository/review/PlanReviewRepository.java
@@ -6,17 +6,12 @@ import com.mople.global.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface PlanReviewRepository extends JpaRepository<PlanReview, Long> {
-
-    @Query("select r from PlanReview r where r.planId = :postId")
-    Optional<PlanReview> findReviewByPostId(Long postId);
 
     @Query("select r from PlanReview r where r.planId in :postIds and r.status = :status")
     List<PlanReview> findReviewsByPostIdIn(List<Long> postIds, Status status);

--- a/src/main/java/com/mople/meet/service/meet/MeetService.java
+++ b/src/main/java/com/mople/meet/service/meet/MeetService.java
@@ -42,6 +42,7 @@ import static com.mople.global.enums.event.AggregateType.MEET;
 import static com.mople.global.enums.ExceptionReturnCode.*;
 import static com.mople.global.enums.event.EventTypeNames.*;
 import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
+import static com.mople.global.utils.cursor.custom.UserCursor.forMeetMember;
 
 @Service
 public class MeetService {
@@ -247,7 +248,7 @@ public class MeetService {
                 throw new CursorException(INVALID_CURSOR);
             }
 
-            cursor = UserCursor.ofUserCursor(member);
+            cursor = forMeetMember(member);
         }
 
         return meetMemberRepositorySupport.findMemberPage(meetId, cursor, size);

--- a/src/main/java/com/mople/meet/service/plan/PlanService.java
+++ b/src/main/java/com/mople/meet/service/plan/PlanService.java
@@ -63,7 +63,7 @@ import static com.mople.global.enums.event.AggregateType.PLAN;
 import static com.mople.global.enums.event.EventTypeNames.*;
 import static com.mople.global.enums.ExceptionReturnCode.*;
 import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
-import static com.mople.global.utils.cursor.custom.UserCursor.ofUserCursor;
+import static com.mople.global.utils.cursor.custom.UserCursor.forPlan;
 
 @Service
 @RequiredArgsConstructor
@@ -415,7 +415,7 @@ public class PlanService {
                 throw new CursorException(INVALID_CURSOR);
             }
 
-            cursor = ofUserCursor(participant);
+            cursor = forPlan(participant);
         }
 
         return participantRepositorySupport.findPlanParticipantPage(planId, cursor, size);

--- a/src/main/java/com/mople/meet/service/review/ReviewService.java
+++ b/src/main/java/com/mople/meet/service/review/ReviewService.java
@@ -58,7 +58,8 @@ import static com.mople.global.enums.event.AggregateType.REVIEW;
 import static com.mople.global.enums.event.EventTypeNames.*;
 import static com.mople.global.enums.ExceptionReturnCode.*;
 import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
-import static com.mople.global.utils.cursor.custom.UserCursor.ofUserCursor;
+import static com.mople.global.utils.cursor.custom.UserCursor.forReview;
+import static com.mople.global.utils.cursor.custom.sort.MemberSortExpressions.deletedOrder;
 
 @Service
 @RequiredArgsConstructor
@@ -256,7 +257,10 @@ public class ReviewService {
                 throw new CursorException(INVALID_CURSOR);
             }
 
-            cursor = ofUserCursor(participant);
+            Status status = userRepository.findById(participant.getUserId())
+                    .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_USER)).getStatus();
+
+            cursor = forReview(participant, deletedOrder(status));
         }
 
         return participantRepositorySupport.findReviewParticipantPage(reviewId, cursor, size);

--- a/src/main/java/com/mople/meet/service/review/ReviewService.java
+++ b/src/main/java/com/mople/meet/service/review/ReviewService.java
@@ -267,7 +267,7 @@ public class ReviewService {
                 .map(PlanParticipant::getUserId)
                 .toList();
 
-        Map<Long, UserInfo> userInfoById = ofMap(userRepository.findByIdInAndStatus(userIds, Status.ACTIVE));
+        Map<Long, UserInfo> userInfoById = ofMap(userRepository.findByIdIn(userIds));
 
         return buildCursorPage(
                 participants,

--- a/src/main/java/com/mople/meet/service/review/ReviewService.java
+++ b/src/main/java/com/mople/meet/service/review/ReviewService.java
@@ -51,7 +51,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.mople.dto.client.ReviewClientResponse.*;
-import static com.mople.dto.client.UserRoleClientResponse.ofParticipants;
+import static com.mople.dto.client.UserRoleClientResponse.*;
 import static com.mople.dto.response.meet.review.ReviewImageListResponse.ofReviewImageResponses;
 import static com.mople.dto.response.user.UserInfo.ofMap;
 import static com.mople.global.enums.event.AggregateType.REVIEW;
@@ -263,7 +263,9 @@ public class ReviewService {
             cursor = forReview(participant, deletedOrder(status));
         }
 
-        return participantRepositorySupport.findReviewParticipantPage(reviewId, cursor, size);
+        List<Long> deletedIds = participantRepositorySupport.findDeletedUserIdsByReviewId(reviewId);
+
+        return participantRepositorySupport.findReviewParticipantPage(reviewId, cursor, size, deletedIds);
     }
 
     private CursorPageResponse<UserRoleClientResponse> buildParticipantCursorPage(int size, List<PlanParticipant> participants) {

--- a/src/main/java/com/mople/user/repository/UserRepository.java
+++ b/src/main/java/com/mople/user/repository/UserRepository.java
@@ -18,6 +18,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.id in :ids and u.status = :status")
     List<User> findByIdInAndStatus(List<Long> ids, Status status);
 
+    @Query("select u from User u where u.id in :ids")
+    List<User> findByIdIn(List<Long> ids);
+
     @Query(
             "select u " +
             "  from User u " +

--- a/src/main/java/com/mople/user/service/SignService.java
+++ b/src/main/java/com/mople/user/service/SignService.java
@@ -60,7 +60,7 @@ public class SignService {
         }
 
         final User user = userRepository.loginCheck(sign.email())
-                .orElseThrow(() -> new AuthException(ExceptionReturnCode.NOT_USER));
+                .orElseThrow(() -> new AuthException(ExceptionReturnCode.NOT_FOUND_USER));
 
         if (!user.getSocialProvider().equals(sign.socialProvider())) {
             throw new AuthException(ExceptionReturnCode.ANOTHER_PROVIDER);


### PR DESCRIPTION
## 에러 페이지 응답 코드 통일, 리뷰 참여자 목록 정렬 조건 추가
---
### 에러 페이지 응답 코드 통일
`plan`, `review`, `meet`, `comment`에서 
하드 삭제된 경우와 소프트 삭제된 경우 응답코드를 `404`로 통일하였습니다!! 
(기존에는 잘못 생각하여 소프트 삭제된 경우를 `400`으로 내렸습니다 🥲)

그리고 접근 권한이 없는 경우 `401`에서 `403`으로 수정하였습니다!!

---
### 리뷰 참여자 목록 정렬 조건 추가
현재 상황
- 최근에 탈퇴 시 리뷰의 참여자 목록에서 지워지지 않는 탈퇴 요구사항이 변경되었습니다.
- 또한 회원 탈퇴한 경우 모든 닉네임을 `탈퇴한 사용자`, 이미지도 삭제 처리만 하고 하드 삭제하지 않습니다.
(댓글, 리뷰 참여자 목록, 좋아요를 유지함)

이 과정에서 리뷰의 참여자 목록에서 회원 탈퇴한 사용자가 `탈퇴한 사용자`라고 닉네임이 수정되었지만
과거 닉네임의 순서대로 정렬되어 중간 중간 `탈퇴한 사용자`가 포함되어 나타났습니다.

`탈퇴한 사용자`를 정렬 조건에 추가하여 맨 밑으로 고정되어 표시하기 위해
리뷰의 참여자 커서에 `deletedOrder` 필드를 추가했습니다.
이 값은 별도로 `Participant` 칼럼에 저장하지 않았습니다...!
(기존에 저장하는 `roleOrder`, `nicknameTypeOrder`, `nicknameLower`과 달리 사용자 상태 기반이기에 조회 시에 계산하도록 하였습니다)

테스트로 확인했습니다!!

---

간단한 pr입니다!!
궁금하신 점이나, 논의하고 싶으신 부분 있으시면 편하게 남겨주세요...! 😊

approve 하시면 `develop` 에 배포한 후 `main`에 merge할 예정입니다!!
항상 감사합니다 대영님 !!