### PR TITLE
Feat/content size

### DIFF
--- a/src/main/java/com/mople/entity/meet/comment/PlanComment.java
+++ b/src/main/java/com/mople/entity/meet/comment/PlanComment.java
@@ -4,6 +4,7 @@ import com.mople.global.enums.Status;
 
 import jakarta.persistence.*;
 
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -22,7 +23,8 @@ public class PlanComment {
     @Version
     private Long version;
 
-    @Column(name = "content", nullable = false, length = 700)
+    @Size(max = 2000)
+    @Column(name = "content", nullable = false, columnDefinition = "text")
     private String content;
 
     @Column(name = "post_id")

--- a/src/main/java/com/mople/entity/meet/plan/MeetPlan.java
+++ b/src/main/java/com/mople/entity/meet/plan/MeetPlan.java
@@ -38,7 +38,7 @@ public class MeetPlan extends BaseTimeEntity {
     @Column(name = "title", length = 50)
     private String title;
 
-    @Column(name = "description", columnDefinition = "TEXT")
+    @Column(name = "description", length = 100)
     private String description;
 
     @Column(name = "lat", precision = 10, scale = 8)

--- a/src/main/java/com/mople/entity/meet/review/PlanReview.java
+++ b/src/main/java/com/mople/entity/meet/review/PlanReview.java
@@ -39,7 +39,7 @@ public class PlanReview extends BaseTimeEntity {
     @Column(name = "title", length = 50)
     private String title;
 
-    @Column(name = "description", columnDefinition = "TEXT")
+    @Column(name = "description", length = 100)
     private String description;
 
     @Column(name = "lat", precision = 10, scale = 8)


### PR DESCRIPTION
## comment 의 content type/크기 수정, plan/review description type 수정
---
### comment 의 content type/크기 수정

댓글에 url 작업을 진행하며 기존 `comment`의 `content`의 700자 제한이 쉽게 넘는 상황이 발생했습니다...!

url 하나에 약 400자 이고, 3 ~ 4개 올릴 수 있도록 해서 2000자로 늘렸습니다...!
그리고 이는 추후에 더 늘리거나 줄일 가능성도 있기 때문에 type 을 `text`로 변경하고, `@Size` 로 최대 크기를 설정해줬습니다.

---
### plan/review description type 수정

기존에 `description`을 개발하며 글자 수가 정해지지 않아 `text`로 임시로 했었습니다...!
지금은 기획에서 100자 로 고정되었기 때문에,
 `text`에서 `var` 타입으로 변경하고 크기도 100자로 제한을 두었습니다!!

---

테스트로 확인하였습니다!!!

궁금하신 부분이나 상의 필요한 부분 있으시면 편하게 요청 주세요 🫡🫡🫡

approve 해주시면 정말로 이 부분까지 main 에 merge 하겠습니다...!! 😂