### PR TITLE
feat: outbox 에러 발생 시 디스코드에 전송

### DIFF
--- a/src/main/java/com/mople/core/aspect/BusinessLogicLoggingAspect.java
+++ b/src/main/java/com/mople/core/aspect/BusinessLogicLoggingAspect.java
@@ -1,12 +1,7 @@
 package com.mople.core.aspect;
 
-import com.mople.global.async.message.DiscordExceptionSender;
-import com.mople.global.event.data.exception.DiscordMessage;
-import com.mople.global.event.data.exception.DiscordMessagePayload;
-import com.mople.global.event.filter.DiscordAlertFilter;
-
+import com.mople.global.event.notifier.HttpDiscordAlertNotifier;
 import com.mople.global.logging.LoggingContextManager;
-import com.mople.global.logging.SensitiveLogger;
 import com.mople.global.logging.logger.BusinessLogicLogger;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -22,17 +17,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.List;
-
 @Aspect
 @Component
 @RequiredArgsConstructor
 public class BusinessLogicLoggingAspect {
     private final BusinessLogicLogger businessLogicLogger;
     private final LoggingContextManager loggingContextManager;
-    private final DiscordExceptionSender exceptionSender;
-    private final SensitiveLogger sensitiveLogger;
-    private final DiscordAlertFilter discordAlertFilter;
+    private final HttpDiscordAlertNotifier httpDiscordAlertNotifier;
 
     @Around("@annotation(com.mople.core.annotation.log.BusinessLogicLogging)")
     public Object processCustomAnnotation(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -55,62 +46,9 @@ public class BusinessLogicLoggingAspect {
 
     @AfterThrowing(pointcut = "execution(* com.mople.*.controller.*.*(..))", throwing = "ex")
     public void processControllerExceptionThrown(JoinPoint point, Throwable ex) {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        HttpServletRequest request =
+                ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
-        // Discord 알림이 필요한 경우만 전송
-        if (discordAlertFilter.shouldAlert(ex, request)) {
-            String message =
-                            """
-                            Request - Method: %s\s
-                            URI: %s
-                            Arguments: %s
-                            exception: %s(message=%s)
-                            Stacktrace: %s
-                            """
-                            .formatted(
-                                    request.getMethod(),
-                                    request.getRequestURI(),
-                                    sensitiveLogger.sensitiveArgs(point.getArgs()),
-                                    ex.getClass(),
-                                    ex.getMessage(),
-                                    getStackTracePreview(ex)
-                            );
-
-            var discordMessage = DiscordMessage
-                    .builder()
-                    .content("# 🚨 Server Critical Exception")
-                    .embeds(
-                            List.of(
-                                    DiscordMessagePayload.builder()
-                                            .title("ℹ️ Error Details")
-                                            .description(message)
-                                            .build()
-                            )
-                    )
-                    .build();
-
-            exceptionSender.exceptionSend(discordMessage);
-        }
-    }
-
-    private String getStackTracePreview(Throwable ex) {
-        StackTraceElement[] stackTrace = ex.getStackTrace();
-
-        if (stackTrace.length == 0) {
-            return "stack trace empty";
-        }
-
-        StringBuilder preview = new StringBuilder();
-        int limit = Math.min(5, stackTrace.length);
-
-        for (int i = 0; i < limit; i++) {
-            preview.append(stackTrace[i].toString()).append("\n");
-        }
-
-        if (stackTrace.length > 5) {
-            preview.append("... and ").append(stackTrace.length - 5).append(" more");
-        }
-
-        return preview.toString();
+        httpDiscordAlertNotifier.notify(point, request, ex);
     }
 }

--- a/src/main/java/com/mople/global/event/filter/HttpDiscordAlertFilter.java
+++ b/src/main/java/com/mople/global/event/filter/HttpDiscordAlertFilter.java
@@ -14,14 +14,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Component
-public class DiscordAlertFilter {
+public class HttpDiscordAlertFilter {
 
     // 인증 실패 카운터 (IP 기준 카운트)
     private final Map<String, AtomicInteger> authFailureCounters = new ConcurrentHashMap<>();
     private static final int AUTH_FAILURE_THRESHOLD = 3;
-    private static final long RESET_INTERVAL_MS = 600000; // 10분
+    private static final long RESET_INTERVAL_MS = 10 * 60 * 1000; // 10분
 
     public boolean shouldAlert(Throwable ex, HttpServletRequest request) {
+
         // 5XX 서버 에러
         if (isServerError(ex)) {
             log.debug("Discord alert: Server error - {}", ex.getClass().getSimpleName());

--- a/src/main/java/com/mople/global/event/filter/OutboxDiscordAlertFilter.java
+++ b/src/main/java/com/mople/global/event/filter/OutboxDiscordAlertFilter.java
@@ -1,0 +1,68 @@
+package com.mople.global.event.filter;
+
+import com.mople.core.exception.custom.NonRetryableOutboxException;
+import com.mople.entity.event.OutboxEvent;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class OutboxDiscordAlertFilter {
+
+    private final ConcurrentHashMap<String, Long> cooldown = new ConcurrentHashMap<>();
+    private static final int ATTEMPT_THRESHOLD = 3;
+    private static final long RESET_INTERVAL_MS = 10 * 60 * 1000; // 10분
+
+    public boolean shouldAlert(Throwable ex, OutboxEvent event) {
+
+        // 치명 예외
+        if (ex instanceof NonRetryableOutboxException) {
+            return passCooldown(event, ex);
+        }
+
+        // DB 계열
+        if (ex instanceof DataAccessException) {
+            return passCooldown(event, ex);
+        }
+
+        // 외부 API 장애
+        if (isExternalApiFailure(ex)) {
+            return passCooldown(event, ex);
+        }
+
+        // 일반 런타임 예외: attempts가 누적
+        Integer attempts = event.getAttempts();
+        if (attempts >= ATTEMPT_THRESHOLD) {
+            return passCooldown(event, ex);
+        }
+
+        return false;
+    }
+
+    private boolean isExternalApiFailure(Throwable ex) {
+
+        return ex instanceof ResourceAccessException ||
+                (ex.getCause() != null && ex.getCause() instanceof IOException) ||
+                (
+                        ex.getMessage() != null &&
+                                (ex.getMessage().contains("External API") || ex.getMessage().contains("외부 API"))
+                );
+    }
+
+    private boolean passCooldown(OutboxEvent event, Throwable ex) {
+        String key = event.getEventId() + "|" + ex.getClass().getName();
+        long now = System.currentTimeMillis();
+
+        Long last = cooldown.put(key, now);
+        if (last == null) return true;
+
+        if (now - last >= RESET_INTERVAL_MS) {
+            cooldown.put(key, now);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/mople/global/event/notifier/HttpDiscordAlertNotifier.java
+++ b/src/main/java/com/mople/global/event/notifier/HttpDiscordAlertNotifier.java
@@ -1,0 +1,58 @@
+package com.mople.global.event.notifier;
+
+import com.mople.global.async.message.DiscordExceptionSender;
+import com.mople.global.event.data.exception.DiscordMessage;
+import com.mople.global.event.data.exception.DiscordMessagePayload;
+import com.mople.global.event.filter.HttpDiscordAlertFilter;
+import com.mople.global.event.notifier.support.StackTracePreviewer;
+import com.mople.global.logging.SensitiveLogger;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class HttpDiscordAlertNotifier {
+
+    private final DiscordExceptionSender exceptionSender;
+    private final SensitiveLogger sensitiveLogger;
+    private final HttpDiscordAlertFilter httpAlertFilter;
+    private final StackTracePreviewer stackTracePreviewer;
+
+    public void notify(JoinPoint point, HttpServletRequest request, Throwable ex) {
+        if (!httpAlertFilter.shouldAlert(ex, request)) {
+            return;
+        }
+
+        String message = """
+                Request - Method: %s
+                URI: %s
+                Arguments: %s
+                exception: %s(message=%s)
+                Stacktrace: %s
+                """
+                .formatted(
+                        request.getMethod(),
+                        request.getRequestURI(),
+                        sensitiveLogger.sensitiveArgs(point.getArgs()),
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        stackTracePreviewer.preview(ex)
+                );
+
+        DiscordMessage discordMessage = DiscordMessage.builder()
+                .content("# 🚨 Server Critical Exception")
+                .embeds(List.of(
+                        DiscordMessagePayload.builder()
+                                .title("ℹ️ Error Details")
+                                .description(message)
+                                .build()
+                ))
+                .build();
+
+        exceptionSender.exceptionSend(discordMessage);
+    }
+}

--- a/src/main/java/com/mople/global/event/notifier/OutboxDiscordAlertNotifier.java
+++ b/src/main/java/com/mople/global/event/notifier/OutboxDiscordAlertNotifier.java
@@ -1,0 +1,103 @@
+package com.mople.global.event.notifier;
+
+import com.mople.entity.event.OutboxEvent;
+import com.mople.global.async.message.DiscordExceptionSender;
+import com.mople.global.event.data.exception.DiscordMessage;
+import com.mople.global.event.data.exception.DiscordMessagePayload;
+import com.mople.global.event.filter.OutboxDiscordAlertFilter;
+import com.mople.global.event.notifier.support.StackTracePreviewer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxDiscordAlertNotifier {
+
+    private final DiscordExceptionSender exceptionSender;
+    private final OutboxDiscordAlertFilter outboxAlertFilter;
+    private final StackTracePreviewer stackTracePreviewer;
+
+    public void notifyOutboxFailure(String title, OutboxEvent event, Throwable ex) {
+        Throwable root = unwrap(ex);
+
+        if (!outboxAlertFilter.shouldAlert(root, event)) {
+            return;
+        }
+
+        String message = """
+                EventId: %s
+                Status: %s
+                Attempts: %s
+                Type: %s
+                exception: %s(message=%s)
+                Stacktrace: %s
+                """
+                .formatted(
+                        safe(event.getEventId()),
+                        safe(event.getStatus()),
+                        safe(event.getAttempts()),
+                        safe(event.getEventType()),
+                        root.getClass().getName(),
+                        root.getMessage(),
+                        stackTracePreviewer.preview(root)
+                );
+
+        DiscordMessage discordMessage = DiscordMessage.builder()
+                .content("# 🚨 Outbox Exception")
+                .embeds(List.of(
+                        DiscordMessagePayload.builder()
+                                .title("ℹ️ " + title)
+                                .description(message)
+                                .build()
+                ))
+                .build();
+
+        exceptionSender.exceptionSend(discordMessage);
+    }
+
+    public void notifyOutboxBatchFailure(String title, Throwable ex) {
+        Throwable root = unwrap(ex);
+
+        String message = """
+                exception: %s(message=%s)
+                Stacktrace: %s
+                """
+                .formatted(
+                        root.getClass().getName(),
+                        root.getMessage(),
+                        stackTracePreviewer.preview(root)
+                );
+
+        DiscordMessage discordMessage = DiscordMessage.builder()
+                .content("# 🚨 Outbox Batch Exception")
+                .embeds(List.of(
+                        DiscordMessagePayload.builder()
+                                .title("ℹ️ " + title)
+                                .description(message)
+                                .build()
+                ))
+                .build();
+
+        exceptionSender.exceptionSend(discordMessage);
+    }
+
+    private Throwable unwrap(Throwable ex) {
+        if (ex instanceof CompletionException && ex.getCause() != null) {
+            return ex.getCause();
+        }
+
+        if (ex instanceof ExecutionException && ex.getCause() != null) {
+            return ex.getCause();
+        }
+
+        return ex;
+    }
+
+    private String safe(Object o) {
+        return String.valueOf(o);
+    }
+}

--- a/src/main/java/com/mople/global/event/notifier/support/StackTracePreviewer.java
+++ b/src/main/java/com/mople/global/event/notifier/support/StackTracePreviewer.java
@@ -1,0 +1,27 @@
+package com.mople.global.event.notifier.support;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class StackTracePreviewer {
+
+    public String preview(Throwable ex) {
+        if (ex == null) return "exception is null";
+
+        StackTraceElement[] stackTrace = ex.getStackTrace();
+        if (stackTrace == null || stackTrace.length == 0) return "stack trace empty";
+
+        int limit = Math.min(5, stackTrace.length);
+        StringBuilder preview = new StringBuilder();
+
+        for (int i = 0; i < limit; i++) {
+            preview.append(stackTrace[i]).append("\n");
+        }
+
+        if (stackTrace.length > limit) {
+            preview.append("... and ").append(stackTrace.length - limit).append(" more");
+        }
+
+        return preview.toString();
+    }
+}

--- a/src/main/java/com/mople/outbox/service/OutboxPublisher.java
+++ b/src/main/java/com/mople/outbox/service/OutboxPublisher.java
@@ -1,6 +1,7 @@
 package com.mople.outbox.service;
 
 import com.mople.entity.event.OutboxEvent;
+import com.mople.global.event.notifier.OutboxDiscordAlertNotifier;
 import com.mople.global.logging.logger.BusinessLogicLogger;
 import com.mople.outbox.repository.OutboxEventRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class OutboxPublisher {
     private final OutboxEventRepository outboxEventRepository;
     private final BusinessLogicLogger logicLogger;
     private final Executor outboxExecutor;
+    private final OutboxDiscordAlertNotifier outboxDiscordAlertNotifier;
 
     @Value("${outbox.batch-size}")
     private int batchSize;
@@ -29,20 +31,28 @@ public class OutboxPublisher {
 
     @Scheduled(fixedDelayString = "${outbox.fixed-delay-ms}")
     public void publishBatch() {
-        List<OutboxEvent> outboxEvents = outboxEventRepository.lockNextBatch(batchSize, leaseSec);
+        try {
+            List<OutboxEvent> outboxEvents = outboxEventRepository.lockNextBatch(batchSize, leaseSec);
 
-        List<CompletableFuture<Void>> futures = outboxEvents.stream()
-                .map(event -> CompletableFuture.runAsync(
-                        () -> processor.processOne(event),
-                        outboxExecutor
-                ).exceptionally(ex -> {
-                    logicLogger.logError("OutboxEvent 처리 실패");
-                    return null;
-                }))
-                .toList();
+            List<CompletableFuture<Void>> futures = outboxEvents.stream()
+                    .map(event -> CompletableFuture.runAsync(
+                            () -> processor.processOne(event),
+                            outboxExecutor
+                    ).whenComplete((v, ex) -> {
+                        if (ex != null) {
+                            outboxDiscordAlertNotifier.notifyOutboxFailure("OutboxEvent 처리 실패", event, ex);
+                            logicLogger.logError("OutboxEvent 처리 실패");
+                        }
+                    }))
+                    .toList();
 
-        CompletableFuture
-                .allOf(futures.toArray(new CompletableFuture[0]))
-                .join();
+            CompletableFuture
+                    .allOf(futures.toArray(new CompletableFuture[0]))
+                    .join();
+
+        } catch (Throwable ex) {
+            outboxDiscordAlertNotifier.notifyOutboxBatchFailure("OutboxEvent 배치 처리 실패", ex);
+            logicLogger.logError("OutboxEvent 배치 처리 실패");
+        }
     }
 }


### PR DESCRIPTION
outboxEvent 에러 디스코드 전송
---
outboxEvent 핸들러 안에서 발생하는 오류는 잡아지지만, 
outboxEvent 자체를 폴링하여 실행하는 로직에서 예외를 조용히 삼키고 있었습니다.

현재 `no-location-event` 가 계속 실패하고 있습니다.
그렇지만 해당 이벤트의 에러 문구는 나오지 않고, `attemps`도 올라가지 않아 계속 가져와서 실행하고 있습니다.
따라서 해당 이벤트를 가져오는 부분도 에러 처리를 하고,
이벤트 개별 에러, 배치 이벤트 에러가 발생하면 디스코드로 알림을 전송하도록 하였습니다!

전송받은 디스코드 에러로 `no-location-event` 가 왜 실행이 안되는지 확인해볼 예정입니다!!