### PR TITLE
Feat/hosted meeting list

### DIFF
--- a/src/main/java/com/mople/dto/client/MeetClientResponse.java
+++ b/src/main/java/com/mople/dto/client/MeetClientResponse.java
@@ -18,7 +18,7 @@ public class MeetClientResponse {
     private final String meetName;
     private final String meetImage;
     private final Long sinceDays;
-    private final Long creatorId;
+    private final Long hostId;
     private final int memberCount;
     private final LocalDateTime lastPlanDay;
 
@@ -32,6 +32,7 @@ public class MeetClientResponse {
                 .version(listResponse.version())
                 .meetName(listResponse.meetName())
                 .meetImage(listResponse.meetImage())
+                .hostId(listResponse.hostId())
                 .memberCount(listResponse.memberCount())
                 .lastPlanDay(listResponse.lastPlanDays())
                 .build();
@@ -43,7 +44,7 @@ public class MeetClientResponse {
                 .version(infoResponse.version())
                 .meetName(infoResponse.meetName())
                 .meetImage(infoResponse.meetImage())
-                .creatorId(infoResponse.creatorId())
+                .hostId(infoResponse.hostId())
                 .sinceDays(infoResponse.meetStartDate())
                 .memberCount(infoResponse.memberCount())
                 .build();

--- a/src/main/java/com/mople/dto/response/meet/MeetInfoResponse.java
+++ b/src/main/java/com/mople/dto/response/meet/MeetInfoResponse.java
@@ -10,7 +10,7 @@ public record MeetInfoResponse(
         Long version,
         String meetName,
         String meetImage,
-        Long creatorId,
+        Long hostId,
         Long meetStartDate,
         Integer memberCount
 ) {

--- a/src/main/java/com/mople/dto/response/meet/MeetListResponse.java
+++ b/src/main/java/com/mople/dto/response/meet/MeetListResponse.java
@@ -7,6 +7,7 @@ public record MeetListResponse(
         Long version,
         String meetName,
         String meetImage,
+        Long hostId,
         Integer memberCount,
         LocalDateTime lastPlanDays
 ) {}

--- a/src/main/java/com/mople/dto/response/meet/plan/PlanHomeViewResponse.java
+++ b/src/main/java/com/mople/dto/response/meet/plan/PlanHomeViewResponse.java
@@ -1,12 +1,11 @@
 package com.mople.dto.response.meet.plan;
 
 import com.mople.dto.client.PlanClientResponse;
-import com.mople.dto.response.meet.MeetListFindMemberResponse;
 
 import java.util.List;
 
 public record PlanHomeViewResponse(
         List<PlanClientResponse> plans,
-        List<MeetListFindMemberResponse> meets
+        boolean hasJoinedMeet
 ) {
 }

--- a/src/main/java/com/mople/meet/controller/MeetController.java
+++ b/src/main/java/com/mople/meet/controller/MeetController.java
@@ -119,6 +119,18 @@ public class MeetController {
     }
 
     @Operation(
+            summary = "모임장인 모임 조회 API",
+            description = "유저가 모임장인 모임 목록을 조회합니다."
+    )
+    @GetMapping("/host/list")
+    public ResponseEntity<CursorPageResponse<MeetClientResponse>> getHostedMeetList(
+            @Parameter(hidden = true) @SignUser AuthUserRequest user,
+            @ParameterObject @Valid CursorPageRequest request
+    ) {
+        return ResponseEntity.ok(meetService.getHostedMeet(user.id(), request));
+    }
+
+    @Operation(
             summary = "모임장 양도 API",
             description = "해당 모임의 모임장 권한을 다른 모임 멤버에게 양도합니다."
     )

--- a/src/main/java/com/mople/meet/repository/impl/MeetRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/MeetRepositorySupport.java
@@ -99,6 +99,7 @@ public class MeetRepositorySupport {
                                 m.getVersion(),
                                 m.getName(),
                                 m.getMeetImage(),
+                                m.getHostId(),
                                 countMeetMember(m.getId()),
                                 meetPlan.getPlanTime()
                         );
@@ -112,6 +113,7 @@ public class MeetRepositorySupport {
                                 m.getVersion(),
                                 m.getName(),
                                 m.getMeetImage(),
+                                m.getHostId(),
                                 countMeetMember(m.getId()),
                                 planReview.getPlanTime()
                         );
@@ -122,6 +124,7 @@ public class MeetRepositorySupport {
                             m.getVersion(),
                             m.getName(),
                             m.getMeetImage(),
+                            m.getHostId(),
                             countMeetMember(m.getId()),
                             null
                     );

--- a/src/main/java/com/mople/meet/repository/impl/MeetRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/MeetRepositorySupport.java
@@ -1,6 +1,5 @@
 package com.mople.meet.repository.impl;
 
-import com.mople.dto.response.meet.MeetListFindMemberResponse;
 import com.mople.dto.response.meet.MeetListResponse;
 
 import com.mople.entity.meet.plan.MeetPlan;
@@ -9,7 +8,6 @@ import com.mople.entity.meet.review.PlanReview;
 import com.mople.entity.meet.review.QPlanReview;
 import com.mople.global.enums.Status;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.mople.entity.meet.*;
 
@@ -132,26 +130,16 @@ public class MeetRepositorySupport {
                 .toList();
     }
 
-    public List<MeetListFindMemberResponse> findMeetUseMember(Long userId) {
-        QMeet meet = QMeet.meet;
-        QMeetMember meetMember = QMeetMember.meetMember;
+    public boolean hasJoinedMeet(Long userId) {
+        QMeetMember mm = QMeetMember.meetMember;
 
-        return queryFactory.select(
-                        Projections.constructor(
-                                MeetListFindMemberResponse.class,
-                                meet.id,
-                                meet.name,
-                                meet.meetImage
-                        )
-                )
-                .from(meet)
-                .join(meetMember).on(meetMember.meetId.eq(meet.id))
-                .where(
-                        meet.status.eq(Status.ACTIVE),
-                        meetMember.userId.eq(userId)
-                )
-                .distinct()
-                .fetch();
+        Integer joined = queryFactory
+                .selectOne()
+                .from(mm)
+                .where(mm.userId.eq(userId))
+                .fetchFirst();
+
+        return joined != null;
     }
 
     public Integer countMeetMember(Long meetId) {

--- a/src/main/java/com/mople/meet/repository/impl/MeetRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/MeetRepositorySupport.java
@@ -46,6 +46,25 @@ public class MeetRepositorySupport {
                 .fetch();
     }
 
+    public List<Meet> findHostedMeetPage(Long userId, Long cursorId, int size) {
+        QMeet meet = QMeet.meet;
+
+        BooleanBuilder whereCondition = new BooleanBuilder()
+                .and(meet.hostId.eq(userId))
+                .and(meet.status.eq(Status.ACTIVE));
+
+        if (cursorId != null) {
+            whereCondition.and(meet.id.gt(cursorId));
+        }
+
+        return queryFactory
+                .selectFrom(meet)
+                .where(whereCondition)
+                .orderBy(meet.id.asc())
+                .limit(size + 1)
+                .fetch();
+    }
+
     public List<MeetListResponse> mapToMeetListResponses(List<Meet> meets) {
         QMeetPlan plan = QMeetPlan.meetPlan;
         QPlanReview review = QPlanReview.planReview;

--- a/src/main/java/com/mople/meet/service/meet/MeetHostTransferService.java
+++ b/src/main/java/com/mople/meet/service/meet/MeetHostTransferService.java
@@ -1,0 +1,120 @@
+package com.mople.meet.service.meet;
+
+import com.mople.core.exception.custom.AuthException;
+import com.mople.core.exception.custom.BadRequestException;
+import com.mople.core.exception.custom.CursorException;
+import com.mople.dto.client.MeetClientResponse;
+import com.mople.dto.event.data.domain.meet.HostChangedEvent;
+import com.mople.dto.request.meet.HostChangeRequest;
+import com.mople.dto.request.pagination.CursorPageRequest;
+import com.mople.dto.response.meet.MeetListResponse;
+import com.mople.dto.response.pagination.CursorPageResponse;
+import com.mople.entity.meet.Meet;
+import com.mople.entity.meet.MeetMember;
+import com.mople.global.enums.UserRole;
+import com.mople.global.utils.cursor.CursorUtils;
+import com.mople.meet.reader.EntityReader;
+import com.mople.meet.repository.MeetMemberRepository;
+import com.mople.meet.repository.impl.MeetRepositorySupport;
+import com.mople.outbox.service.OutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.mople.global.enums.ExceptionReturnCode.*;
+import static com.mople.global.enums.event.AggregateType.MEET;
+import static com.mople.global.enums.event.EventTypeNames.MEET_HOST_CHANGED;
+import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
+
+@Service
+@RequiredArgsConstructor
+public class MeetHostTransferService {
+
+    private static final int MEET_CURSOR_FIELD_COUNT = 1;
+
+    private final MeetRepositorySupport meetRepositorySupport;
+    private final MeetMemberRepository meetMemberRepository;
+    private final OutboxService outboxService;
+    private final EntityReader reader;
+
+    public void changeMeetHost(Long userId, Long meetId, HostChangeRequest request) {
+        Long newHostId = request.newHostId();
+
+        reader.findUser(userId);
+        reader.findUser(newHostId);
+        Meet meet = reader.findMeet(meetId);
+
+        if (!meetMemberRepository.existsByMeetIdAndUserId(meetId, userId) ||
+                !meetMemberRepository.existsByMeetIdAndUserId(meetId, newHostId)
+        ) {
+            throw new BadRequestException(NOT_MEMBER);
+        }
+
+        if (!meet.matchHost(userId)) {
+            throw new AuthException(NOT_CREATOR);
+        }
+
+        if (newHostId.equals(userId)) {
+            throw new BadRequestException(CURRENT_HOST);
+        }
+
+        meet.changeHost(newHostId);
+
+        MeetMember oldHostMember = meetMemberRepository.findMeetIdAndUserId(meetId, userId);
+        MeetMember newHostMember = meetMemberRepository.findMeetIdAndUserId(meetId, newHostId);
+
+        oldHostMember.changeRole(UserRole.PARTICIPANT);
+        newHostMember.changeRole(UserRole.HOST);
+
+        HostChangedEvent changedEvent = HostChangedEvent.builder()
+                .meetId(meetId)
+                .oldHostId(userId)
+                .newHostId(newHostId)
+                .build();
+
+        outboxService.save(MEET_HOST_CHANGED, MEET, meetId, changedEvent);
+    }
+
+    public CursorPageResponse<MeetClientResponse> getHostedMeet(Long userId, CursorPageRequest request) {
+        reader.findUser(userId);
+
+        int size = request.getSafeSize();
+        List<Meet> meets = getHostedMeets(userId, request.cursor(), size);
+
+        List<MeetListResponse> meetListResponses = meetRepositorySupport.mapToMeetListResponses(meets);
+
+        return buildMeetCursorPage(size, meetListResponses);
+    }
+
+    private List<Meet> getHostedMeets(Long userId, String encodedCursor, int size) {
+
+        Long cursorId = null;
+
+        if (encodedCursor != null && !encodedCursor.isEmpty()) {
+            String[] decodeParts = CursorUtils.decode(encodedCursor, MEET_CURSOR_FIELD_COUNT);
+            cursorId = Long.valueOf(decodeParts[0]);
+
+            validateCursor(cursorId);
+        }
+
+        return meetRepositorySupport.findHostedMeetPage(userId, cursorId, size);
+    }
+
+    private CursorPageResponse<MeetClientResponse> buildMeetCursorPage(int size, List<MeetListResponse> meetListResponses) {
+        return buildCursorPage(
+                meetListResponses,
+                size,
+                r -> new String[]{
+                        r.meetId().toString()
+                },
+                MeetClientResponse::ofListMeets
+        );
+    }
+
+    private void validateCursor(Long cursorId) {
+        if (meetRepositorySupport.isCursorInvalid(cursorId)) {
+            throw new CursorException(INVALID_CURSOR);
+        }
+    }
+}

--- a/src/main/java/com/mople/meet/service/meet/MeetService.java
+++ b/src/main/java/com/mople/meet/service/meet/MeetService.java
@@ -14,7 +14,6 @@ import com.mople.dto.response.pagination.FlatCursorPageResponse;
 import com.mople.dto.response.user.UserInfo;
 import com.mople.entity.user.User;
 import com.mople.global.enums.Status;
-import com.mople.global.enums.UserRole;
 import com.mople.global.utils.cursor.custom.UserCursor;
 import com.mople.global.utils.cursor.CursorUtils;
 import com.mople.meet.reader.EntityReader;
@@ -23,6 +22,7 @@ import com.mople.meet.repository.impl.MeetRepositorySupport;
 import com.mople.entity.meet.*;
 import com.mople.meet.repository.*;
 
+import com.mople.meet.service.meet.member.MeetMemberAutoCompleteService;
 import com.mople.outbox.service.OutboxService;
 import com.mople.user.repository.UserRepository;
 import jakarta.persistence.OptimisticLockException;
@@ -59,6 +59,7 @@ public class MeetService {
     private final OutboxService outboxService;
     private final MeetRemoveService meetRemoveService;
     private final MeetMemberAutoCompleteService autoCompleteService;
+    private final MeetHostTransferService meetHostTransferService;
     private final EntityReader reader;
 
     private final String inviteUrl;
@@ -73,6 +74,7 @@ public class MeetService {
             OutboxService outboxService,
             MeetRemoveService meetRemoveService,
             MeetMemberAutoCompleteService autoCompleteService,
+            MeetHostTransferService meetHostTransferService,
             EntityReader reader,
             @Value("${mople.url}") String inviteUrl
     ) {
@@ -85,6 +87,7 @@ public class MeetService {
         this.outboxService = outboxService;
         this.meetRemoveService = meetRemoveService;
         this.autoCompleteService = autoCompleteService;
+        this.meetHostTransferService = meetHostTransferService;
         this.reader = reader;
         this.inviteUrl = inviteUrl;
     }
@@ -294,41 +297,12 @@ public class MeetService {
 
     @Transactional
     public void changeMeetHost(Long userId, Long meetId, HostChangeRequest request) {
-        Long newHostId = request.newHostId();
+        meetHostTransferService.changeMeetHost(userId, meetId, request);
+    }
 
-        reader.findUser(userId);
-        reader.findUser(newHostId);
-        Meet meet = reader.findMeet(meetId);
-
-        if (!meetMemberRepository.existsByMeetIdAndUserId(meetId, userId) ||
-                !meetMemberRepository.existsByMeetIdAndUserId(meetId, newHostId)
-        ) {
-            throw new BadRequestException(NOT_MEMBER);
-        }
-
-        if (!meet.matchHost(userId)) {
-            throw new AuthException(NOT_CREATOR);
-        }
-
-        if (newHostId.equals(userId)) {
-            throw new BadRequestException(CURRENT_HOST);
-        }
-
-        meet.changeHost(newHostId);
-
-        MeetMember oldHostMember = meetMemberRepository.findMeetIdAndUserId(meetId, userId);
-        MeetMember newHostMember = meetMemberRepository.findMeetIdAndUserId(meetId, newHostId);
-
-        oldHostMember.changeRole(UserRole.PARTICIPANT);
-        newHostMember.changeRole(UserRole.HOST);
-
-        HostChangedEvent changedEvent = HostChangedEvent.builder()
-                .meetId(meetId)
-                .oldHostId(userId)
-                .newHostId(newHostId)
-                .build();
-
-        outboxService.save(MEET_HOST_CHANGED, MEET, meetId, changedEvent);
+    @Transactional(readOnly = true)
+    public CursorPageResponse<MeetClientResponse> getHostedMeet(Long userId, CursorPageRequest request) {
+        return meetHostTransferService.getHostedMeet(userId, request);
     }
 
     @Transactional

--- a/src/main/java/com/mople/meet/service/meet/member/MeetMemberAutoCompleteService.java
+++ b/src/main/java/com/mople/meet/service/meet/member/MeetMemberAutoCompleteService.java
@@ -1,4 +1,4 @@
-package com.mople.meet.service.meet;
+package com.mople.meet.service.meet.member;
 
 import com.mople.core.exception.custom.CursorException;
 import com.mople.dto.client.UserRoleClientResponse;

--- a/src/main/java/com/mople/meet/service/plan/PlanService.java
+++ b/src/main/java/com/mople/meet/service/plan/PlanService.java
@@ -95,7 +95,7 @@ public class PlanService {
 
         return new PlanHomeViewResponse(
                 ofViews(homeViewPlan),
-                meetRepositorySupport.findMeetUseMember(userId)
+                meetRepositorySupport.hasJoinedMeet(userId)
         );
     }
 


### PR DESCRIPTION
## 홈화면 api 에서 모임 참여 여부 전달, 모임장인 모임 리스트 불러오는 api 추가
---
### 홈화면 api 에서 모임 참여 여부 전달

우선 `plan/view` 응답 dto에서 모임 리스트를 페이징 없이 보내주어 수정했어야 했습니다..!
클라이언트 분들과 얘기 나눠본 결과, 참여한 모임이 있는지 여부만 boolean 값으로 내려주기로 했습니다..!

---
###  모임장인 모임 리스트 불러오는 api 추가

모임장 양도 기능에서 모임장인 모임 리스트만 따로 불러와야 했습니다.
따라서 기존 모임 리스트 api를 사용해볼까 했지만, 
1. 모임장에게만 사용되는 api,
2. ui 및 사용처가 다름
따라서 별도 api 로 만들어 주었습니다.

그리고 `meetService `에서 모임장 양도 기능까지는 너무 많은 책임인 것 같아 별도 클래스로 분리했습니다.  
이제 슬슬 코드도 많아지고, 기능도 많아지니 클래스 나누는 리팩토링이 필요할 거 같습니다...! (중복 로직도 꽤 있어요!)

---


대영님 편하신 시간대 말씀주시면 같이 얘기 나눠봐요!!
항상 감사합니다 대영님!!  