### PR TITLE
feat: 모임장 조회 API에서 멤버가 1이상인 모임만 조회하도록 변경

### DIFF
--- a/src/main/java/com/mople/meet/repository/impl/MeetRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/MeetRepositorySupport.java
@@ -10,6 +10,7 @@ import com.mople.entity.meet.review.QPlanReview;
 import com.mople.global.enums.Status;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.mople.entity.meet.*;
 
@@ -50,6 +51,7 @@ public class MeetRepositorySupport {
 
     public List<Meet> findHostedMeetPage(Long userId, Long cursorId, int size) {
         QMeet meet = QMeet.meet;
+        QMeetMember meetMember = QMeetMember.meetMember;
 
         BooleanBuilder whereCondition = new BooleanBuilder()
                 .and(meet.hostId.eq(userId))
@@ -61,7 +63,12 @@ public class MeetRepositorySupport {
 
         return queryFactory
                 .selectFrom(meet)
-                .where(whereCondition)
+                .where(whereCondition,
+                        JPAExpressions
+                                .select(meetMember.count())
+                                .from(meetMember)
+                                .where(meetMember.meetId.eq(meet.id))
+                                .gt(1L))
                 .orderBy(meet.id.asc())
                 .limit(size + 1)
                 .fetch();

--- a/src/main/java/com/mople/meet/repository/plan/MeetPlanRepository.java
+++ b/src/main/java/com/mople/meet/repository/plan/MeetPlanRepository.java
@@ -6,8 +6,6 @@ import com.mople.global.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;


### PR DESCRIPTION
기존 모임장 조회 api 에서 모임장이지만 혼자만 존재하는 모임도 리스트로 내려주었습니다.
모임장 양도이기 때문에 멤버가 1인 모임은 제외하고 내려주도록 수정했습니다!

