### PR TITLE
단건 공지 조회, 시스템/커스텀 공지 별로 조회, 삭제 이벤트 추가

### DIFF
--- a/src/main/java/com/mople/dto/event/data/domain/DomainEvent.java
+++ b/src/main/java/com/mople/dto/event/data/domain/DomainEvent.java
@@ -9,6 +9,8 @@ import com.mople.dto.event.data.domain.comment.CommentsSoftDeletedEvent;
 import com.mople.dto.event.data.domain.image.ImageDeletedEvent;
 import com.mople.dto.event.data.domain.meet.*;
 import com.mople.dto.event.data.domain.global.NotifyRequestedEvent;
+import com.mople.dto.event.data.domain.notice.NoticePurgeEvent;
+import com.mople.dto.event.data.domain.notice.NoticeSoftDeletedEvent;
 import com.mople.dto.event.data.domain.plan.*;
 import com.mople.dto.event.data.domain.review.*;
 import com.mople.dto.event.data.domain.user.UserDeletedEvent;
@@ -36,6 +38,10 @@ import static com.mople.global.enums.event.EventTypeNames.*;
         @JsonSubTypes.Type(value = HostChangedEvent.class, name = MEET_HOST_CHANGED),
         @JsonSubTypes.Type(value = MeetJoinedEvent.class, name = MEET_JOINED),
         @JsonSubTypes.Type(value = MeetImageChangedEvent.class, name = MEET_IMAGE_CHANGED),
+
+        // Notice
+        @JsonSubTypes.Type(value = NoticeSoftDeletedEvent.class, name = NOTICE_SOFT_DELETED),
+        @JsonSubTypes.Type(value = NoticePurgeEvent.class, name = NOTICE_PURGE),
 
         // Plan
         @JsonSubTypes.Type(value = PlanSoftDeletedEvent.class, name = PLAN_SOFT_DELETED),

--- a/src/main/java/com/mople/dto/event/data/domain/comment/CommentsSoftDeletedEvent.java
+++ b/src/main/java/com/mople/dto/event/data/domain/comment/CommentsSoftDeletedEvent.java
@@ -1,13 +1,15 @@
 package com.mople.dto.event.data.domain.comment;
 
 import com.mople.dto.event.data.domain.DomainEvent;
+import com.mople.global.enums.CommentTarget;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
 public record CommentsSoftDeletedEvent(
-        Long postId,
+        CommentTarget target,
+        Long targetId,
         List<Long> commentIds,
         Long commentsDeletedBy
 ) implements DomainEvent {

--- a/src/main/java/com/mople/dto/event/data/domain/notice/NoticePurgeEvent.java
+++ b/src/main/java/com/mople/dto/event/data/domain/notice/NoticePurgeEvent.java
@@ -1,0 +1,10 @@
+package com.mople.dto.event.data.domain.notice;
+
+import com.mople.dto.event.data.domain.DomainEvent;
+import lombok.Builder;
+
+@Builder
+public record NoticePurgeEvent(
+        Long noticeId
+) implements DomainEvent {
+}

--- a/src/main/java/com/mople/dto/event/data/domain/notice/NoticeSoftDeletedEvent.java
+++ b/src/main/java/com/mople/dto/event/data/domain/notice/NoticeSoftDeletedEvent.java
@@ -1,0 +1,11 @@
+package com.mople.dto.event.data.domain.notice;
+
+import com.mople.dto.event.data.domain.DomainEvent;
+import lombok.Builder;
+
+@Builder
+public record NoticeSoftDeletedEvent(
+        Long noticeId,
+        Long noticeDeletedBy
+) implements DomainEvent {
+}

--- a/src/main/java/com/mople/global/enums/CommentTarget.java
+++ b/src/main/java/com/mople/global/enums/CommentTarget.java
@@ -1,5 +1,18 @@
 package com.mople.global.enums;
 
+import com.mople.global.enums.event.AggregateType;
+
 public enum CommentTarget {
-    POST, NOTICE
+    POST(AggregateType.POST),
+    NOTICE(AggregateType.NOTICE);
+
+    private final AggregateType aggregateType;
+
+    CommentTarget(AggregateType aggregateType) {
+        this.aggregateType = aggregateType;
+    }
+
+    public AggregateType toAggregateType() {
+        return aggregateType;
+    }
 }

--- a/src/main/java/com/mople/global/enums/event/AggregateType.java
+++ b/src/main/java/com/mople/global/enums/event/AggregateType.java
@@ -1,5 +1,5 @@
 package com.mople.global.enums.event;
 
 public enum AggregateType {
-    MEET, POST, PLAN, REVIEW, COMMENT, USER
+    MEET, NOTICE, POST, PLAN, REVIEW, COMMENT, USER
 }

--- a/src/main/java/com/mople/global/enums/event/EventTypeNames.java
+++ b/src/main/java/com/mople/global/enums/event/EventTypeNames.java
@@ -10,6 +10,10 @@ public final class EventTypeNames {
     public static final String MEET_HOST_CHANGED = "MEET_HOST_CHANGED";
     public static final String MEET_PURGE = "MEET_PURGE";
 
+    // NOTICE
+    public static final String NOTICE_SOFT_DELETED = "NOTICE_SOFT_DELETED";
+    public static final String NOTICE_PURGE = "NOTICE_PURGE";
+
     // PLAN
     public static final String PLAN_CREATED = "PLAN_CREATED";
     public static final String PLAN_SOFT_DELETED = "PLAN_SOFT_DELETED";  // 작성자로 탈퇴 시 작성자 PLAN 모두 삭제

--- a/src/main/java/com/mople/global/event/handler/domain/impl/comment/delete/CommentsPurgeRegisterHandler.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/comment/delete/CommentsPurgeRegisterHandler.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 
-import static com.mople.global.enums.event.AggregateType.*;
 import static com.mople.global.enums.event.EventTypeNames.COMMENTS_PURGE;
 
 @Component
@@ -31,6 +30,6 @@ public class CommentsPurgeRegisterHandler implements DomainEventHandler<Comments
                 .commentIds(event.commentIds())
                 .build();
 
-        outboxService.saveWithRunAt(COMMENTS_PURGE, POST, event.postId(), runAt, purgeEvent);
+        outboxService.saveWithRunAt(COMMENTS_PURGE, event.target().toAggregateType(), event.targetId(), runAt, purgeEvent);
     }
 }

--- a/src/main/java/com/mople/global/event/handler/domain/impl/meet/delete/MeetCleanupHandler.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/meet/delete/MeetCleanupHandler.java
@@ -10,7 +10,6 @@ import com.mople.global.event.handler.domain.DomainEventHandler;
 import com.mople.meet.repository.MeetInviteRepository;
 import com.mople.meet.repository.MeetMemberRepository;
 import com.mople.meet.repository.MeetRepository;
-import com.mople.meet.repository.notice.MeetNoticeRepository;
 import com.mople.outbox.service.OutboxService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -25,7 +24,6 @@ public class MeetCleanupHandler implements DomainEventHandler<MeetSoftDeletedEve
     private final MeetRepository meetRepository;
     private final MeetMemberRepository memberRepository;
     private final MeetInviteRepository inviteRepository;
-    private final MeetNoticeRepository noticeRepository;
     private final OutboxService outboxService;
 
     @Override
@@ -40,7 +38,6 @@ public class MeetCleanupHandler implements DomainEventHandler<MeetSoftDeletedEve
 
         memberRepository.deleteByMeetId(event.meetId());
         inviteRepository.deleteByMeetId(event.meetId());
-        noticeRepository.deleteByMeetId(event.meetId());
 
         if (meet.getMeetImage() == null || meet.getMeetImage().isBlank()) {
             return;

--- a/src/main/java/com/mople/global/event/handler/domain/impl/meet/delete/MeetDeletedFanoutHandler.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/meet/delete/MeetDeletedFanoutHandler.java
@@ -1,10 +1,12 @@
 package com.mople.global.event.handler.domain.impl.meet.delete;
 
 import com.mople.dto.event.data.domain.meet.MeetSoftDeletedEvent;
+import com.mople.dto.event.data.domain.notice.NoticeSoftDeletedEvent;
 import com.mople.dto.event.data.domain.plan.PlanSoftDeletedEvent;
 import com.mople.dto.event.data.domain.review.ReviewSoftDeletedEvent;
 import com.mople.global.enums.event.DeletionCause;
 import com.mople.global.event.handler.domain.DomainEventHandler;
+import com.mople.meet.repository.notice.MeetNoticeRepository;
 import com.mople.meet.repository.plan.MeetPlanRepository;
 import com.mople.meet.repository.review.PlanReviewRepository;
 import com.mople.outbox.service.OutboxService;
@@ -25,6 +27,7 @@ public class MeetDeletedFanoutHandler implements DomainEventHandler<MeetSoftDele
 
     private final MeetPlanRepository planRepository;
     private final PlanReviewRepository reviewRepository;
+    private final MeetNoticeRepository noticeRepository;
     private final OutboxService outboxService;
 
     @Override
@@ -36,9 +39,11 @@ public class MeetDeletedFanoutHandler implements DomainEventHandler<MeetSoftDele
     public void handle(MeetSoftDeletedEvent event) {
         List<Long> planIds = planRepository.findIdsByMeetId(event.meetId());
         List<Long> reviewIds = reviewRepository.findIdsByMeetId(event.meetId());
+        List<Long> noticeIds = noticeRepository.findIdsByMeetId(event.meetId());
 
         planRepository.softDeleteAll(DELETED, planIds, event.meetDeletedBy(), LocalDateTime.now());
         reviewRepository.softDeleteAll(DELETED, reviewIds, event.meetDeletedBy(), LocalDateTime.now());
+        noticeRepository.softDeleteAll(DELETED, noticeIds, event.meetDeletedBy(), LocalDateTime.now());
 
         chunk(planIds, ids ->
             ids.forEach(id -> {
@@ -61,6 +66,17 @@ public class MeetDeletedFanoutHandler implements DomainEventHandler<MeetSoftDele
                         .build();
 
                 outboxService.save(REVIEW_SOFT_DELETED, REVIEW, id, deleteEvent);
+            })
+        );
+
+        chunk(noticeIds, ids ->
+            ids.forEach(id -> {
+                NoticeSoftDeletedEvent deleteEvent = NoticeSoftDeletedEvent.builder()
+                        .noticeId(id)
+                        .noticeDeletedBy(event.meetDeletedBy())
+                        .build();
+
+                outboxService.save(NOTICE_SOFT_DELETED, NOTICE, id, deleteEvent);
             })
         );
     }

--- a/src/main/java/com/mople/global/event/handler/domain/impl/notice/delete/NoticeDeletedFanoutHandler.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/notice/delete/NoticeDeletedFanoutHandler.java
@@ -1,7 +1,7 @@
-package com.mople.global.event.handler.domain.impl.plan.delete;
+package com.mople.global.event.handler.domain.impl.notice.delete;
 
 import com.mople.dto.event.data.domain.comment.CommentsSoftDeletedEvent;
-import com.mople.dto.event.data.domain.plan.PlanSoftDeletedEvent;
+import com.mople.dto.event.data.domain.notice.NoticeSoftDeletedEvent;
 import com.mople.global.enums.CommentTarget;
 import com.mople.global.event.handler.domain.DomainEventHandler;
 import com.mople.meet.repository.comment.MeetCommentRepository;
@@ -13,36 +13,36 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.mople.global.enums.Status.DELETED;
-import static com.mople.global.enums.event.AggregateType.POST;
+import static com.mople.global.enums.event.AggregateType.NOTICE;
 import static com.mople.global.enums.event.EventTypeNames.COMMENTS_SOFT_DELETED;
 import static com.mople.global.utils.batch.Batching.chunk;
 
 @Component
 @RequiredArgsConstructor
-public class PlanDeletedFanoutHandler implements DomainEventHandler<PlanSoftDeletedEvent> {
+public class NoticeDeletedFanoutHandler implements DomainEventHandler<NoticeSoftDeletedEvent> {
 
     private final MeetCommentRepository commentRepository;
     private final OutboxService outboxService;
 
     @Override
-    public Class<PlanSoftDeletedEvent> getHandledType() {
-        return PlanSoftDeletedEvent.class;
+    public Class<NoticeSoftDeletedEvent> getHandledType() {
+        return NoticeSoftDeletedEvent.class;
     }
 
     @Override
-    public void handle(PlanSoftDeletedEvent event) {
-        List<Long> commentIds = commentRepository.findIdByTargetAndTargetId(CommentTarget.POST, event.planId());
-        commentRepository.softDeleteAll(DELETED, commentIds, event.planDeletedBy(), LocalDateTime.now());
+    public void handle(NoticeSoftDeletedEvent event) {
+        List<Long> commentIds = commentRepository.findIdByTargetAndTargetId(CommentTarget.NOTICE, event.noticeId());
+        commentRepository.softDeleteAll(DELETED, commentIds, event.noticeDeletedBy(), LocalDateTime.now());
 
         chunk(commentIds, ids -> {
             CommentsSoftDeletedEvent deleteEvent = CommentsSoftDeletedEvent.builder()
-                    .target(CommentTarget.POST)
-                    .targetId(event.planId())
+                    .target(CommentTarget.NOTICE)
+                    .targetId(event.noticeId())
                     .commentIds(ids)
-                    .commentsDeletedBy(event.planDeletedBy())
+                    .commentsDeletedBy(event.noticeDeletedBy())
                     .build();
 
-            outboxService.save(COMMENTS_SOFT_DELETED, POST, event.planId(), deleteEvent);
+            outboxService.save(COMMENTS_SOFT_DELETED, NOTICE, event.noticeId(), deleteEvent);
         });
     }
 }

--- a/src/main/java/com/mople/global/event/handler/domain/impl/notice/delete/NoticePurgeRegisterHandler.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/notice/delete/NoticePurgeRegisterHandler.java
@@ -1,0 +1,36 @@
+package com.mople.global.event.handler.domain.impl.notice.delete;
+
+import com.mople.dto.event.data.domain.notice.NoticePurgeEvent;
+import com.mople.dto.event.data.domain.notice.NoticeSoftDeletedEvent;
+import com.mople.global.event.handler.domain.DomainEventHandler;
+import com.mople.outbox.service.OutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+import static com.mople.global.enums.event.AggregateType.NOTICE;
+import static com.mople.global.enums.event.EventTypeNames.NOTICE_PURGE;
+
+@Component
+@RequiredArgsConstructor
+public class NoticePurgeRegisterHandler implements DomainEventHandler<NoticeSoftDeletedEvent> {
+
+    private final OutboxService outboxService;
+
+    @Override
+    public Class<NoticeSoftDeletedEvent> getHandledType() {
+        return NoticeSoftDeletedEvent.class;
+    }
+
+    @Override
+    public void handle(NoticeSoftDeletedEvent event) {
+        LocalDateTime runAt = LocalDateTime.now().plusDays(7);
+
+        NoticePurgeEvent purgeEvent = NoticePurgeEvent.builder()
+                .noticeId(event.noticeId())
+                .build();
+
+        outboxService.saveWithRunAt(NOTICE_PURGE, NOTICE, event.noticeId(), runAt, purgeEvent);
+    }
+}

--- a/src/main/java/com/mople/global/event/handler/domain/impl/notice/delete/purge/NoticePurgeHandler.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/notice/delete/purge/NoticePurgeHandler.java
@@ -1,0 +1,24 @@
+package com.mople.global.event.handler.domain.impl.notice.delete.purge;
+
+import com.mople.dto.event.data.domain.notice.NoticePurgeEvent;
+import com.mople.global.event.handler.domain.DomainEventHandler;
+import com.mople.meet.repository.notice.MeetNoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NoticePurgeHandler implements DomainEventHandler<NoticePurgeEvent> {
+
+    private final MeetNoticeRepository noticeRepository;
+
+    @Override
+    public Class<NoticePurgeEvent> getHandledType() {
+        return NoticePurgeEvent.class;
+    }
+
+    @Override
+    public void handle(NoticePurgeEvent event) {
+        noticeRepository.hardDeleteById(event.noticeId());
+    }
+}

--- a/src/main/java/com/mople/global/event/handler/domain/impl/review/delete/ReviewDeletedFanoutHandler.java
+++ b/src/main/java/com/mople/global/event/handler/domain/impl/review/delete/ReviewDeletedFanoutHandler.java
@@ -36,7 +36,8 @@ public class ReviewDeletedFanoutHandler implements DomainEventHandler<ReviewSoft
 
         chunk(commentIds, ids -> {
             CommentsSoftDeletedEvent deleteEvent = CommentsSoftDeletedEvent.builder()
-                    .postId(event.planId())
+                    .target(CommentTarget.POST)
+                    .targetId(event.planId())
                     .commentIds(ids)
                     .commentsDeletedBy(event.reviewDeletedBy())
                     .build();

--- a/src/main/java/com/mople/meet/controller/NoticeController.java
+++ b/src/main/java/com/mople/meet/controller/NoticeController.java
@@ -7,6 +7,7 @@ import com.mople.dto.request.meet.notice.NoticeUpdateRequest;
 import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.request.user.AuthUserRequest;
 import com.mople.dto.response.pagination.CursorPageResponse;
+import com.mople.global.enums.notice.NoticeType;
 import com.mople.meet.service.notice.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,9 +34,10 @@ public class NoticeController {
     public ResponseEntity<CursorPageResponse<NoticeClientResponse>> getMeetNoticeList(
             @Parameter(hidden = true) @SignUser AuthUserRequest user,
             @PathVariable Long meetId,
+            @RequestParam(required = false) NoticeType type,
             @ParameterObject @Valid CursorPageRequest request
     ) {
-        return ResponseEntity.ok(noticeService.getNoticeList(user.id(), meetId, request));
+        return ResponseEntity.ok(noticeService.getNoticeList(user.id(), meetId, type, request));
     }
 
     @Operation(

--- a/src/main/java/com/mople/meet/controller/NoticeController.java
+++ b/src/main/java/com/mople/meet/controller/NoticeController.java
@@ -39,6 +39,22 @@ public class NoticeController {
     }
 
     @Operation(
+            summary = "특정 공지 조회 API",
+            description = "모임의 특정 공지를 상세 조회합니다."
+    )
+    @GetMapping("/detail/{noticeId}")
+    public ResponseEntity<NoticeClientResponse> getMeetingPlanDetail(
+            @Parameter(hidden = true) @SignUser AuthUserRequest user,
+            @PathVariable Long noticeId
+    ) {
+        var body = noticeService.getSpecNotice(user.id(), noticeId);
+
+        return ResponseEntity.ok()
+                .eTag("\"" + body.getVersion() + "\"")
+                .body(body);
+    }
+
+    @Operation(
             summary = "공지 생성 API",
             description = "모임장이 공지를 생성하고, 생성된 공지 정보를 반환합니다."
     )

--- a/src/main/java/com/mople/meet/repository/impl/notice/NoticeRepositorySupport.java
+++ b/src/main/java/com/mople/meet/repository/impl/notice/NoticeRepositorySupport.java
@@ -2,6 +2,7 @@ package com.mople.meet.repository.impl.notice;
 
 import com.mople.entity.meet.notice.MeetNotice;
 import com.mople.entity.meet.notice.QMeetNotice;
+import com.mople.global.enums.notice.NoticeType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -17,11 +18,15 @@ public class NoticeRepositorySupport {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<MeetNotice> findNoticePage(Long meetId, Long cursorId, int size) {
+    public List<MeetNotice> findNoticePage(Long meetId, NoticeType type, Long cursorId, int size) {
         QMeetNotice notice = QMeetNotice.meetNotice;
 
         BooleanBuilder whereCondition = new BooleanBuilder()
                 .and(notice.meetId.eq(meetId));
+
+        if (type != null) {
+            whereCondition.and(notice.type.eq(type));
+        }
 
         if (cursorId != null) {
             LocalDateTime cursorWriteTime = queryFactory

--- a/src/main/java/com/mople/meet/repository/notice/MeetNoticeRepository.java
+++ b/src/main/java/com/mople/meet/repository/notice/MeetNoticeRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MeetNoticeRepository extends JpaRepository<MeetNotice, Long> {
@@ -23,5 +25,30 @@ public interface MeetNoticeRepository extends JpaRepository<MeetNotice, Long> {
     @Query("select n from MeetNotice n where n.meetId = :meetId and n.pinnedAt is not null")
     MeetNotice findPinnedNotice(Long meetId);
 
-    void deleteByMeetId(Long meetId);
+    @Modifying(flushAutomatically = true)
+    @Query(
+            "update MeetNotice n " +
+                    "   set n.status = :status, " +
+                    "       n.deletedAt = :deletedAt, " +
+                    "       n.deletedBy = :userId " +
+                    " where n.id in :noticeIds " +
+                    "   and n.status <> :status"
+    )
+    int softDeleteAll(Status status, List<Long> noticeIds, Long userId, LocalDateTime deletedAt);
+
+    @Query(
+            "select n.id " +
+                    "  from MeetNotice n " +
+                    " where n.meetId = :meetId " +
+                    "   and n.status = com.mople.global.enums.Status.ACTIVE"
+    )
+    List<Long> findIdsByMeetId(Long meetId);
+
+    @Modifying(flushAutomatically = true)
+    @Query(
+            "delete from MeetNotice n " +
+                    "      where n.id = :noticeId " +
+                    "        and n.status = com.mople.global.enums.Status.DELETED"
+    )
+    void hardDeleteById(Long noticeId);
 }

--- a/src/main/java/com/mople/meet/service/comment/CommentService.java
+++ b/src/main/java/com/mople/meet/service/comment/CommentService.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.mople.global.enums.ExceptionReturnCode.*;
-import static com.mople.global.enums.event.AggregateType.POST;
 import static com.mople.global.enums.event.EventTypeNames.COMMENTS_SOFT_DELETED;
 
 @Service
@@ -115,17 +114,18 @@ public class CommentService {
         }
 
         commentRepository.softDeleteAll(Status.DELETED, commentIdsToDelete, userId, LocalDateTime.now());
-        generateCommentsDeletedEvent(commentIdsToDelete, targetId, comment.getWriterId());
+        generateCommentsDeletedEvent(commentIdsToDelete, type, targetId, comment.getWriterId());
     }
 
-    private void generateCommentsDeletedEvent(List<Long> commentIds, Long postId, Long writerId) {
+    private void generateCommentsDeletedEvent(List<Long> commentIds, CommentTarget type, Long targetId, Long writerId) {
         CommentsSoftDeletedEvent deletedEvent = CommentsSoftDeletedEvent.builder()
-                .postId(postId)
+                .target(type)
+                .targetId(targetId)
                 .commentIds(commentIds)
                 .commentsDeletedBy(writerId)
                 .build();
 
-        outboxService.save(COMMENTS_SOFT_DELETED, POST, postId, deletedEvent);
+        outboxService.save(COMMENTS_SOFT_DELETED, type.toAggregateType(), targetId, deletedEvent);
     }
 
     private Long getMeetId(CommentTarget type, Long targetId) {

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -8,6 +8,7 @@ import com.mople.dto.request.pagination.CursorPageRequest;
 import com.mople.dto.response.pagination.CursorPageResponse;
 import com.mople.entity.meet.Meet;
 import com.mople.entity.meet.notice.MeetNotice;
+import com.mople.global.enums.Status;
 import com.mople.global.utils.cursor.CursorUtils;
 import com.mople.meet.reader.EntityReader;
 import com.mople.meet.repository.MeetMemberRepository;
@@ -77,6 +78,19 @@ public class NoticeService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public NoticeClientResponse getSpecNotice(Long userId, Long noticeId) {
+        reader.findUser(userId);
+        MeetNotice notice = reader.findNotice(noticeId);
+        Long meetId = notice.getMeetId();
+
+        if (!memberRepository.existsByMeetIdAndUserId(meetId, userId)) {
+            throw new AuthException(NOT_MEMBER);
+        }
+
+        return ofNotice(notice);
+    }
+
     private void validateCursor(Long cursorId) {
         if (noticeRepositorySupport.isCursorInvalid(cursorId)) {
             throw new CursorException(INVALID_CURSOR);
@@ -112,7 +126,7 @@ public class NoticeService {
             throw new AuthException(NOT_HOST);
         }
 
-        MeetNotice customNotice = meetNoticeRepository.findById(noticeId)
+        MeetNotice customNotice = meetNoticeRepository.findByIdAndStatus(noticeId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_NOTICE));
 
         if (!customNotice.getMeetId().equals(meetId)) {
@@ -140,7 +154,7 @@ public class NoticeService {
     public void removeNotice(Long userId, Long noticeId) {
         reader.findUser(userId);
 
-        MeetNotice customNotice = meetNoticeRepository.findById(noticeId)
+        MeetNotice customNotice = meetNoticeRepository.findByIdAndStatus(noticeId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_NOTICE));
 
         Meet meet = reader.findMeet(customNotice.getMeetId());
@@ -149,14 +163,15 @@ public class NoticeService {
             throw new AuthException(NOT_HOST);
         }
 
-        meetNoticeRepository.delete(customNotice);
+        meet.softDelete(userId);
+        //todo. purge 이벤트 발행
     }
 
     @Transactional
     public NoticeClientResponse pinNotice(Long userId, Long noticeId) {
         reader.findUser(userId);
 
-        MeetNotice notice = meetNoticeRepository.findById(noticeId)
+        MeetNotice notice = meetNoticeRepository.findByIdAndStatus(noticeId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_NOTICE));
 
         Meet meet = reader.findMeet(notice.getMeetId());
@@ -181,7 +196,7 @@ public class NoticeService {
     public NoticeClientResponse unpinNotice(Long userId, Long noticeId) {
         reader.findUser(userId);
 
-        MeetNotice notice = meetNoticeRepository.findById(noticeId)
+        MeetNotice notice = meetNoticeRepository.findByIdAndStatus(noticeId, Status.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException(NOT_FOUND_NOTICE));
 
         Meet meet = reader.findMeet(notice.getMeetId());

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -9,6 +9,7 @@ import com.mople.dto.response.pagination.CursorPageResponse;
 import com.mople.entity.meet.Meet;
 import com.mople.entity.meet.notice.MeetNotice;
 import com.mople.global.enums.Status;
+import com.mople.global.enums.notice.NoticeType;
 import com.mople.global.utils.cursor.CursorUtils;
 import com.mople.meet.reader.EntityReader;
 import com.mople.meet.repository.MeetMemberRepository;
@@ -39,7 +40,7 @@ public class NoticeService {
     private final NoticeRepositorySupport noticeRepositorySupport;
 
     @Transactional(readOnly = true)
-    public CursorPageResponse<NoticeClientResponse> getNoticeList(Long userId, Long meetId, CursorPageRequest request) {
+    public CursorPageResponse<NoticeClientResponse> getNoticeList(Long userId, Long meetId, NoticeType type, CursorPageRequest request) {
         reader.findUser(userId);
         reader.findMeet(meetId);
 
@@ -48,12 +49,12 @@ public class NoticeService {
         }
 
         int size = request.getSafeSize();
-        List<MeetNotice> notices = getNotices(meetId, request.cursor(), size);
+        List<MeetNotice> notices = getNotices(meetId, type, request.cursor(), size);
 
         return buildNoticeCursorPage(size, notices);
     }
 
-    private List<MeetNotice> getNotices(Long meetId, String encodedCursor, int size) {
+    private List<MeetNotice> getNotices(Long meetId, NoticeType type, String encodedCursor, int size) {
 
         Long cursorId = null;
 
@@ -64,7 +65,7 @@ public class NoticeService {
             validateCursor(cursorId);
         }
 
-        return noticeRepositorySupport.findNoticePage(meetId, cursorId, size);
+        return noticeRepositorySupport.findNoticePage(meetId, type, cursorId, size);
     }
 
     private CursorPageResponse<NoticeClientResponse> buildNoticeCursorPage(int size, List<MeetNotice> notices) {

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -2,6 +2,7 @@ package com.mople.meet.service.notice;
 
 import com.mople.core.exception.custom.*;
 import com.mople.dto.client.NoticeClientResponse;
+import com.mople.dto.event.data.domain.notice.NoticeSoftDeletedEvent;
 import com.mople.dto.request.meet.notice.NoticeCreateRequest;
 import com.mople.dto.request.meet.notice.NoticeUpdateRequest;
 import com.mople.dto.request.pagination.CursorPageRequest;
@@ -15,6 +16,7 @@ import com.mople.meet.reader.EntityReader;
 import com.mople.meet.repository.MeetMemberRepository;
 import com.mople.meet.repository.impl.notice.NoticeRepositorySupport;
 import com.mople.meet.repository.notice.MeetNoticeRepository;
+import com.mople.outbox.service.OutboxService;
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.StaleObjectStateException;
@@ -26,6 +28,8 @@ import java.util.List;
 
 import static com.mople.dto.client.NoticeClientResponse.ofNotice;
 import static com.mople.global.enums.ExceptionReturnCode.*;
+import static com.mople.global.enums.event.AggregateType.NOTICE;
+import static com.mople.global.enums.event.EventTypeNames.NOTICE_SOFT_DELETED;
 import static com.mople.global.utils.cursor.CursorUtils.buildCursorPage;
 
 @Service
@@ -38,6 +42,7 @@ public class NoticeService {
     private final MeetNoticeRepository meetNoticeRepository;
     private final MeetMemberRepository memberRepository;
     private final NoticeRepositorySupport noticeRepositorySupport;
+    private final OutboxService outboxService;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<NoticeClientResponse> getNoticeList(Long userId, Long meetId, NoticeType type, CursorPageRequest request) {
@@ -164,8 +169,14 @@ public class NoticeService {
             throw new AuthException(NOT_HOST);
         }
 
-        meet.softDelete(userId);
-        //todo. purge 이벤트 발행
+        customNotice.softDelete(userId);
+
+        NoticeSoftDeletedEvent deleteEvent = NoticeSoftDeletedEvent.builder()
+                .noticeId(customNotice.getId())
+                .noticeDeletedBy(userId)
+                .build();
+
+        outboxService.save(NOTICE_SOFT_DELETED, NOTICE, customNotice.getId(), deleteEvent);
     }
 
     @Transactional


### PR DESCRIPTION
## 단건 공지 조회
`noticeId` 로 단건 공지 조회하는 api 를 추가했습니다!

---
## 시스템/커스텀 공지 별로 조회
기존에는 시스템/커스텀 공지를 구분하지 않고 전체 목록만 조회하는 api 였습니다.
따라서 `?type=CUSTOM` `?type=SYSTEM` 쿼리파라미터로 
하나의 api 에서 해당 타입 별로 공지 목록을 조회할 수 있도록 수정했습니다...! 

---
## 삭제 이벤트 추가
  - 모임 삭제 시 공지 soft delete 처리
  - 공지 삭제 시 공지 댓글 soft delete 및 purge 예약 처리

---
테스트 모두 완료했습니다 대영님...! 