### PR TITLE
fix: 시스템 공지 writer null 에러 수정

### DIFF
--- a/src/main/java/com/mople/dto/client/NoticeClientResponse.java
+++ b/src/main/java/com/mople/dto/client/NoticeClientResponse.java
@@ -24,7 +24,14 @@ public class NoticeClientResponse {
 
     public static List<NoticeClientResponse> ofNotices(List<MeetNotice> notices, Map<Long, UserInfo> userInfoById) {
         return notices.stream()
-                .map(notice -> ofNotice(notice, userInfoById.get(notice.getCreatorId())))
+                .map(notice -> {
+                    Long creatorId = notice.getCreatorId();
+                    UserInfo writerInfo = creatorId == null
+                            ? null
+                            : userInfoById.get(creatorId);
+
+                    return ofNotice(notice, writerInfo);
+                })
                 .toList();
     }
 

--- a/src/main/java/com/mople/meet/service/notice/NoticeService.java
+++ b/src/main/java/com/mople/meet/service/notice/NoticeService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.mople.dto.client.NoticeClientResponse.ofNotice;
 import static com.mople.dto.client.NoticeClientResponse.ofNotices;
@@ -84,6 +85,8 @@ public class NoticeService {
     private CursorPageResponse<NoticeClientResponse> buildNoticeCursorPage(int size, List<MeetNotice> notices) {
         List<Long> userIds = notices.stream()
                 .map(MeetNotice::getCreatorId)
+                .filter(Objects::nonNull)
+                .distinct()
                 .toList();
 
         Map<Long, UserInfo> userInfoById = ofMap(userRepository.findByIdInAndStatus(userIds, Status.ACTIVE));
@@ -106,6 +109,10 @@ public class NoticeService {
 
         if (!memberRepository.existsByMeetIdAndUserId(meetId, userId)) {
             throw new AuthException(NOT_MEMBER);
+        }
+
+        if (notice.getType() == NoticeType.SYSTEM) {
+            return ofNotice(notice, null);
         }
 
         User writer = reader.findUser(notice.getCreatorId());


### PR DESCRIPTION
- 시스템 공지의 `creatorId`가 null인 경우 writer를 null로 내려주도록 수정
- 공지 목록/상세 조회에서 시스템 공지 작성자 조회 로직 예외 처리